### PR TITLE
[DOP-13010] - add owner_id to namespace, namespace_history

### DIFF
--- a/docs/changelog/next_release/26.feature.rst
+++ b/docs/changelog/next_release/26.feature.rst
@@ -1,0 +1,1 @@
+Add ``owner_id`` field to ``Namespace`` model to keep track of the owner of the namespace.

--- a/horizon/backend/db/migrations/versions/2024-02-29_09be8fd79dbc_.py
+++ b/horizon/backend/db/migrations/versions/2024-02-29_09be8fd79dbc_.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2023-2024 MTS (Mobile Telesystems)
+# SPDX-License-Identifier: Apache-2.0
+"""Add owner_id to namespace
+
+Revision ID: 09be8fd79dbc
+Revises: 2452f82ae06c
+Create Date: 2024-02-29 11:22:25.802243
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "09be8fd79dbc"
+down_revision = "2452f82ae06c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("namespace", sa.Column("owner_id", sa.BigInteger(), nullable=True))
+    op.create_foreign_key(
+        op.f("fk__namespace__owner_id__user"),
+        "namespace",
+        "user",
+        ["owner_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.add_column("namespace_history", sa.Column("owner_id", sa.BigInteger(), nullable=True))
+    op.create_foreign_key(
+        op.f("fk__namespace_history__owner_id__user"),
+        "namespace_history",
+        "user",
+        ["owner_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.execute(
+        """
+        UPDATE namespace
+        SET owner_id = changed_by_user_id
+        WHERE owner_id IS NULL
+        """,
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(op.f("fk__namespace_history__owner_id__user"), "namespace_history", type_="foreignkey")
+    op.drop_column("namespace_history", "owner_id")
+    op.drop_constraint(op.f("fk__namespace__owner_id__user"), "namespace", type_="foreignkey")
+    op.drop_column("namespace", "owner_id")

--- a/horizon/backend/db/migrations/versions/2024-02-29_09be8fd79dbc_.py
+++ b/horizon/backend/db/migrations/versions/2024-02-29_09be8fd79dbc_.py
@@ -44,6 +44,13 @@ def upgrade() -> None:
         ["id"],
         ondelete="SET NULL",
     )
+    op.execute(
+        """
+        INSERT INTO namespace_history (namespace_id, name, description, action, owner_id, changed_by_user_id)
+        SELECT id, name, description, 'Set owner (automatic migration)', owner_id, NULL
+        FROM namespace
+        """,
+    )
 
 
 def downgrade() -> None:

--- a/horizon/backend/db/migrations/versions/2024-02-29_09be8fd79dbc_.py
+++ b/horizon/backend/db/migrations/versions/2024-02-29_09be8fd79dbc_.py
@@ -19,13 +19,21 @@ depends_on = None
 
 def upgrade() -> None:
     op.add_column("namespace", sa.Column("owner_id", sa.BigInteger(), nullable=True))
+    op.execute(
+        """
+        UPDATE namespace
+        SET owner_id = changed_by_user_id
+        WHERE owner_id IS NULL
+        """,
+    )
+    op.alter_column("namespace", "owner_id", nullable=False)
     op.create_foreign_key(
         op.f("fk__namespace__owner_id__user"),
         "namespace",
         "user",
         ["owner_id"],
         ["id"],
-        ondelete="SET NULL",
+        ondelete="RESTRICT",
     )
     op.add_column("namespace_history", sa.Column("owner_id", sa.BigInteger(), nullable=True))
     op.create_foreign_key(
@@ -35,13 +43,6 @@ def upgrade() -> None:
         ["owner_id"],
         ["id"],
         ondelete="SET NULL",
-    )
-    op.execute(
-        """
-        UPDATE namespace
-        SET owner_id = changed_by_user_id
-        WHERE owner_id IS NULL
-        """,
     )
 
 

--- a/horizon/backend/db/mixins/changed_by.py
+++ b/horizon/backend/db/mixins/changed_by.py
@@ -26,7 +26,7 @@ class ChangedByMixin:
 
     @declared_attr
     def changed_by_user(cls):
-        return relationship(User, lazy="selectin")
+        return relationship(User, foreign_keys=[cls.changed_by_user_id], lazy="selectin")
 
     @declared_attr
     def changed_by(cls):

--- a/horizon/backend/db/models/namespace.py
+++ b/horizon/backend/db/models/namespace.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2023-2024 MTS (Mobile Telesystems)
 # SPDX-License-Identifier: Apache-2.0
 from sqlalchemy import BigInteger, ForeignKey, String, Text
+from sqlalchemy.ext.associationproxy import AssociationProxy, association_proxy
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from horizon.backend.db.mixins.changed_by import ChangedByMixin
@@ -23,7 +24,8 @@ class Namespace(Base, ChangedByMixin):
     )
     owner_id: Mapped[int] = mapped_column(
         BigInteger,
-        ForeignKey("user.id", ondelete="SET NULL"),
-        nullable=True,
+        ForeignKey("user.id", ondelete="RESTRICT"),
+        nullable=False,
     )
     owner = relationship("User", foreign_keys=[owner_id])
+    owned_by: AssociationProxy[str] = association_proxy("owner", "username")

--- a/horizon/backend/db/models/namespace.py
+++ b/horizon/backend/db/models/namespace.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-2024 MTS (Mobile Telesystems)
 # SPDX-License-Identifier: Apache-2.0
-from sqlalchemy import BigInteger, String, Text
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy import BigInteger, ForeignKey, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from horizon.backend.db.mixins.changed_by import ChangedByMixin
 from horizon.backend.db.models.base import Base
@@ -21,3 +21,9 @@ class Namespace(Base, ChangedByMixin):
         Text(),
         nullable=False,
     )
+    owner_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    owner = relationship("User", foreign_keys=[owner_id])

--- a/horizon/backend/db/models/namespace_history.py
+++ b/horizon/backend/db/models/namespace_history.py
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: 2023-2024 MTS (Mobile Telesystems)
 # SPDX-License-Identifier: Apache-2.0
 
-from sqlalchemy import BigInteger, String, Text
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy import BigInteger, ForeignKey, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from horizon.backend.db.mixins.changed_by import ChangedByMixin
 from horizon.backend.db.models.base import Base
@@ -17,3 +17,9 @@ class NamespaceHistory(Base, ChangedByMixin):
     name: Mapped[str] = mapped_column(String(2048), nullable=False)  # noqa: WPS432
     description: Mapped[str] = mapped_column(Text(), nullable=False)
     action: Mapped[str] = mapped_column(String(255), nullable=False)  # noqa: WPS432
+    owner_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    owner = relationship("User", foreign_keys=[owner_id])

--- a/horizon/backend/db/models/namespace_history.py
+++ b/horizon/backend/db/models/namespace_history.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from sqlalchemy import BigInteger, ForeignKey, String, Text
+from sqlalchemy.ext.associationproxy import AssociationProxy, association_proxy
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from horizon.backend.db.mixins.changed_by import ChangedByMixin
@@ -23,3 +24,4 @@ class NamespaceHistory(Base, ChangedByMixin):
         nullable=True,
     )
     owner = relationship("User", foreign_keys=[owner_id])
+    owned_by: AssociationProxy[str] = association_proxy("owner", "username")

--- a/horizon/backend/db/repositories/namespace.py
+++ b/horizon/backend/db/repositories/namespace.py
@@ -57,6 +57,7 @@ class NamespaceRepository(Repository[Namespace]):
                     "name": name,
                     "description": description,
                     "changed_by_user_id": user.id,
+                    "owner_id": user.id,
                 },
             )
             await self._session.flush()

--- a/horizon/commons/schemas/v1/namespace.py
+++ b/horizon/commons/schemas/v1/namespace.py
@@ -17,6 +17,7 @@ class NamespaceResponseV1(BaseModel):
     id: int = Field(description="Namespace id")
     name: str = Field(description="Namespace name, unique in the entire database")
     description: str = Field(description="Namespace description")
+    owned_by: str = Field(description="The namespace owner")
     changed_at: datetime = Field(description="Timestamp of last change of the namespace data")
     changed_by: Optional[str] = Field(default=None, description="Latest user who changed the namespace data")
 

--- a/horizon/commons/schemas/v1/namespace_history.py
+++ b/horizon/commons/schemas/v1/namespace_history.py
@@ -24,6 +24,7 @@ class NamespaceHistoryResponseV1(BaseModel):
     namespace_id: int = Field(description="Namespace id history is bound to")
     name: str = Field(description="Namespace name")
     description: str = Field(description="Namespace description")
+    owned_by: Optional[str] = Field(default=None, description="The namespace owner")
     action: str = Field(description="Action performed on the namespace record")
     changed_at: datetime = Field(description="Timestamp of a change of the namespace data")
     changed_by: Optional[str] = Field(default=None, description="User who changed the namespace data")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,7 +257,7 @@ exclude_lines = [
   "if sys.version_info",
   "@(abc\\.)?abstractmethod",
   "\\.\\.\\.",
-  "def downgrade\\(\\):",
+  "def downgrade\\(\\)",
 ]
 
 [tool.black]

--- a/tests/factories/namespace.py
+++ b/tests/factories/namespace.py
@@ -22,7 +22,6 @@ def namespace_factory(**kwargs):
         "name": random_string(),
         "description": random_string(),
         "changed_at": datetime.now(timezone.utc),
-        "owner_id": randint(0, 10000000),
     }
     data.update(kwargs)
     return Namespace(**data)

--- a/tests/factories/namespace_history.py
+++ b/tests/factories/namespace_history.py
@@ -22,6 +22,7 @@ def namespace_history_factory(**kwargs):
         "name": random_string(),
         "description": random_string(),
         "changed_at": datetime.now(timezone.utc),
+        "owner_id": randint(0, 10000000),
         "action": "Created",
     }
     data.update(kwargs)
@@ -37,7 +38,8 @@ async def namespace_history_items(
 ) -> AsyncGenerator[list[NamespaceHistory], None]:
     size, params = request.param
     result = [
-        namespace_history_factory(namespace_id=namespace.id, changed_by_user_id=user.id, **params) for _ in range(size)
+        namespace_history_factory(namespace_id=namespace.id, changed_by_user_id=user.id, owner_id=user.id, **params)
+        for _ in range(size)
     ]
 
     # do not use the same session in tests and fixture teardown
@@ -52,7 +54,7 @@ async def namespace_history_items(
 
         for item in result:
             # before removing object from Session load all relationships
-            await async_session.refresh(item, attribute_names=["changed_by_user"])
+            await async_session.refresh(item, attribute_names=["changed_by_user", "owner"])
             async_session.expunge(item)
 
     yield result

--- a/tests/factories/namespace_history.py
+++ b/tests/factories/namespace_history.py
@@ -22,7 +22,6 @@ def namespace_history_factory(**kwargs):
         "name": random_string(),
         "description": random_string(),
         "changed_at": datetime.now(timezone.utc),
-        "owner_id": randint(0, 10000000),
         "action": "Created",
     }
     data.update(kwargs)

--- a/tests/factories/user.py
+++ b/tests/factories/user.py
@@ -11,7 +11,7 @@ import pytest_asyncio
 from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from horizon.backend.db.models import User
+from horizon.backend.db.models import Namespace, User
 from tests.factories.base import random_string
 
 
@@ -63,9 +63,11 @@ async def user(
 
     yield user
 
-    query = delete(User).where(User.id == user_id)
+    namespace_query = delete(Namespace).where(Namespace.owner_id == user_id)
+    user_query = delete(User).where(User.id == user_id)
     async with async_session_factory() as async_session:
-        await async_session.execute(query)
+        await async_session.execute(namespace_query)
+        await async_session.execute(user_query)
         await async_session.commit()
 
 

--- a/tests/test_backend/test_namespace/test_create_namespace.py
+++ b/tests/test_backend/test_namespace/test_create_namespace.py
@@ -84,6 +84,7 @@ async def test_create_namespace(
     assert created_namespace.description == content["description"]
     assert created_namespace.changed_at == changed_at
     assert created_namespace.changed_by_user_id == user.id
+    assert created_namespace.owner_id == user.id
 
     query = select(NamespaceHistory).where(NamespaceHistory.namespace_id == namespace_id)
     query_result = await async_session.scalars(query)
@@ -94,6 +95,7 @@ async def test_create_namespace(
     assert created_namespace_history.description == content["description"]
     assert created_namespace_history.changed_at == changed_at
     assert created_namespace_history.changed_by_user_id == user.id
+    assert created_namespace_history.owner_id == user.id
     assert created_namespace_history.action == "Created"
 
 

--- a/tests/test_backend/test_namespace/test_delete_namespace.py
+++ b/tests/test_backend/test_namespace/test_delete_namespace.py
@@ -88,6 +88,7 @@ async def test_delete_namespace(
     assert created_namespace_history.description == namespace.description
     assert created_namespace_history.action == "Deleted"
     assert created_namespace_history.changed_by_user_id == user.id
+    assert created_namespace_history.owner_id == user.id
     assert pre_delete_timestamp <= created_namespace_history.changed_at <= post_delete_timestamp
 
 

--- a/tests/test_backend/test_namespace/test_get_namespace.py
+++ b/tests/test_backend/test_namespace/test_get_namespace.py
@@ -81,4 +81,5 @@ async def test_get_namespace(
         "description": real_namespace.description,
         "changed_at": real_namespace.changed_at,
         "changed_by": real_namespace.changed_by_user.username,
+        "owned_by": real_namespace.owner.username,
     }

--- a/tests/test_backend/test_namespace/test_paginate_namespace.py
+++ b/tests/test_backend/test_namespace/test_paginate_namespace.py
@@ -91,6 +91,7 @@ async def test_paginate_namespaces(
             "description": namespace.description,
             "changed_at": namespace.changed_at,
             "changed_by": namespace.changed_by,
+            "owned_by": namespace.owned_by,
         }
 
 
@@ -132,6 +133,7 @@ async def test_paginate_namespaces_filter_by_name(
             "description": namespace.description,
             "changed_at": namespace.changed_at,
             "changed_by": namespace.changed_by,
+            "owned_by": namespace.owned_by,
         }
     ]
 

--- a/tests/test_backend/test_namespace/test_paginate_namespace_history.py
+++ b/tests/test_backend/test_namespace/test_paginate_namespace_history.py
@@ -168,4 +168,5 @@ async def test_paginate_namespace_history(
             "action": namespace_history_item.action,
             "changed_at": namespace_history_item.changed_at,
             "changed_by": namespace_history_item.changed_by,
+            "owned_by": namespace_history_item.owned_by,
         }

--- a/tests/test_client_sync/test_namespaces/test_client_sync_create_namespace.py
+++ b/tests/test_client_sync/test_namespaces/test_client_sync_create_namespace.py
@@ -20,7 +20,9 @@ pytestmark = [pytest.mark.client_sync, pytest.mark.client]
 
 
 def test_sync_client_create_namespace(new_namespace: Namespace, user: User, sync_client: HorizonClientSync):
-    to_create = NamespaceCreateRequestV1(name=new_namespace.name, description=new_namespace.description)
+    to_create = NamespaceCreateRequestV1(
+        name=new_namespace.name, description=new_namespace.description, owner_id=user.id
+    )
     response = sync_client.create_namespace(to_create)
 
     assert isinstance(response, NamespaceResponseV1)
@@ -28,6 +30,7 @@ def test_sync_client_create_namespace(new_namespace: Namespace, user: User, sync
         name=to_create.name,
         description=to_create.description,
         changed_by=user.username,
+        owned_by=user.username,
     )
 
 

--- a/tests/test_client_sync/test_namespaces/test_client_sync_get_namespace.py
+++ b/tests/test_client_sync/test_namespaces/test_client_sync_get_namespace.py
@@ -28,6 +28,7 @@ def test_sync_client_get_namespace(namespace: Namespace, sync_client: HorizonCli
         description=namespace.description,
         changed_at=namespace.changed_at,
         changed_by=namespace.changed_by,
+        owned_by=namespace.owned_by,
     )
 
 

--- a/tests/test_client_sync/test_namespaces/test_client_sync_paginate_namespace.py
+++ b/tests/test_client_sync/test_namespaces/test_client_sync_paginate_namespace.py
@@ -30,6 +30,7 @@ def test_sync_client_paginate_namespaces(namespaces: list[Namespace], sync_clien
             description=namespace.description,
             changed_at=namespace.changed_at,
             changed_by=namespace.changed_by,
+            owned_by=namespace.owned_by,
         )
         for namespace in namespaces
     ]
@@ -72,6 +73,7 @@ def test_sync_client_paginate_namespaces_filter_by_name(namespaces: list[Namespa
                 description=namespace.description,
                 changed_at=namespace.changed_at,
                 changed_by=namespace.changed_by,
+                owned_by=namespace.owned_by,
             ),
         ],
     )
@@ -90,6 +92,7 @@ def test_sync_client_paginate_namespaces_page_options(
             description=namespace.description,
             changed_at=namespace.changed_at,
             changed_by=namespace.changed_by,
+            owned_by=namespace.owned_by,
         )
         for namespace in namespaces
     ]

--- a/tests/test_client_sync/test_namespaces/test_client_sync_paginate_namespace_history.py
+++ b/tests/test_client_sync/test_namespaces/test_client_sync_paginate_namespace_history.py
@@ -36,6 +36,7 @@ def test_sync_client_paginate_namespace_history(
             action=item.action,
             changed_at=item.changed_at,
             changed_by=item.changed_by,
+            owned_by=item.owned_by,
         )
         for item in namespace_history_items
     ]
@@ -71,6 +72,7 @@ def test_sync_client_paginate_namespace_history_page_options(
             description=item.description,
             changed_at=item.changed_at,
             changed_by=item.changed_by,
+            owned_by=item.owned_by,
             action=item.action,
         )
         for item in namespace_history_items

--- a/tests/test_client_sync/test_namespaces/test_client_sync_update_namespace.py
+++ b/tests/test_client_sync/test_namespaces/test_client_sync_update_namespace.py
@@ -34,6 +34,7 @@ def test_sync_client_update_namespace_name(
         name=new_namespace.name,
         description=namespace.description,
         changed_by=user.username,
+        owned_by=user.username,
     )
 
 
@@ -52,6 +53,7 @@ def test_sync_client_update_namespace_description(
         name=namespace.name,
         description=new_namespace.description,
         changed_by=user.username,
+        owned_by=user.username,
     )
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/horizon/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

- Add ``owner_id`` field to ``Namespace`` model to keep track of the owner of the namespace.
- Add ``owned_by`` association to render `owner` in response data
- Update following tests and documentation

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [x] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/horizon/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
