### PR TITLE
[DOP-13013] - implement API to interact with namespace permissions

### DIFF
--- a/docs/changelog/next_release/29.feature.rst
+++ b/docs/changelog/next_release/29.feature.rst
@@ -1,0 +1,3 @@
+- Add new API endpoint ``PATCH /namespace/:id/permissions`` for updating the permissions of users within a namespace.
+- Add new API endpoint ``GET /namespace/:id/permissions`` for fetching the permissions of users within a specific namespace.
+- Extend the Python client library with methods `get_namespace_permissions` and `update_namespace_permissions` to interact with the new API endpoints.

--- a/docs/client/exceptions.rst
+++ b/docs/client/exceptions.rst
@@ -31,6 +31,9 @@ Permissions
      :members: message, details, required_role, actual_role
      :member-order: bysource
 
+.. autoclass:: BadRequestError
+     :members: reason
+     :member-order: bysource
 
 Entity
 ------

--- a/docs/client/schemas/index.rst
+++ b/docs/client/schemas/index.rst
@@ -15,6 +15,7 @@ All of then are based on Pydantic models.
     namespace_history
     hwm
     hwm_history
+    permissions
 
     user
     ping

--- a/docs/client/schemas/permissions.rst
+++ b/docs/client/schemas/permissions.rst
@@ -1,0 +1,18 @@
+.. _client-schemas-permissions:
+
+Permissions-related schemas
+=========================
+
+.. currentmodule:: horizon.commons.schemas.v1.permission
+
+.. autopydantic_model:: PermissionResponseItemV1
+    :model-show-field-summary: false
+
+.. autopydantic_model:: PermissionsResponseV1
+    :model-show-field-summary: false
+
+.. autopydantic_model:: PermissionUpdateRequestItemV1
+    :model-show-field-summary: false
+
+.. autopydantic_model:: PermissionsUpdateRequestV1
+    :model-show-field-summary: false

--- a/docs/client/schemas/permissions.rst
+++ b/docs/client/schemas/permissions.rst
@@ -1,7 +1,7 @@
 .. _client-schemas-permissions:
 
 Permissions-related schemas
-=========================
+===========================
 
 .. currentmodule:: horizon.commons.schemas.v1.permission
 

--- a/docs/client/sync.rst
+++ b/docs/client/sync.rst
@@ -77,7 +77,7 @@ Reference
 .. currentmodule:: horizon.client.sync
 
 .. autoclass:: HorizonClientSync
-    :members: authorize, ping, whoami, paginate_namespaces, get_namespace, create_namespace, update_namespace, delete_namespace, paginate_hwm, get_hwm, create_hwm, update_hwm, delete_hwm, paginate_hwm_history, paginate_namespace_history, retry
+    :members: authorize, ping, whoami, paginate_namespaces, get_namespace, create_namespace, update_namespace, delete_namespace, paginate_hwm, get_hwm, create_hwm, update_hwm, delete_hwm, get_namespace_permissions, update_namespace_permissions, paginate_hwm_history, paginate_namespace_history, retry
     :member-order: bysource
 
 .. autoclass:: RetryConfig

--- a/horizon/backend/api/v1/router/__init__.py
+++ b/horizon/backend/api/v1/router/__init__.py
@@ -9,6 +9,7 @@ from horizon.backend.api.v1.router.namespace_history import (
     router as namespace_history_router,
 )
 from horizon.backend.api.v1.router.namespaces import router as namespaces_router
+from horizon.backend.api.v1.router.permission import router as permission_router
 from horizon.backend.api.v1.router.users import router as users_router
 
 router = APIRouter(prefix="/v1")
@@ -18,3 +19,4 @@ router.include_router(namespaces_router)
 router.include_router(hwm_router)
 router.include_router(hwm_history_router)
 router.include_router(namespace_history_router)
+router.include_router(permission_router)

--- a/horizon/backend/api/v1/router/hwm.py
+++ b/horizon/backend/api/v1/router/hwm.py
@@ -4,7 +4,7 @@
 from fastapi import APIRouter, Depends, status
 from typing_extensions import Annotated
 
-from horizon.backend.db.models import NamespaceUserRole, User
+from horizon.backend.db.models import NamespaceUserRoleInt, User
 from horizon.backend.services import UnitOfWork, current_user
 from horizon.commons.errors import get_error_responses
 from horizon.commons.schemas.v1 import (
@@ -57,7 +57,7 @@ async def create_hwm(
     async with unit_of_work:
         await unit_of_work.namespace.check_user_permission(
             user_id=user.id,
-            required_role=NamespaceUserRole.DEVELOPER,
+            required_role=NamespaceUserRoleInt.DEVELOPER,
             namespace_id=data.namespace_id,
         )
         hwm = await unit_of_work.hwm.create(
@@ -85,7 +85,7 @@ async def update_hwm(
         hwm = await unit_of_work.hwm.get(hwm_id)
         await unit_of_work.namespace.check_user_permission(
             user_id=user.id,
-            required_role=NamespaceUserRole.DEVELOPER,
+            required_role=NamespaceUserRoleInt.DEVELOPER,
             namespace_id=hwm.namespace_id,
         )
         hwm = await unit_of_work.hwm.update(
@@ -117,7 +117,7 @@ async def delete_hwm(
         hwm = await unit_of_work.hwm.get(hwm_id)
         await unit_of_work.namespace.check_user_permission(
             user_id=user.id,
-            required_role=NamespaceUserRole.MAINTAINER,
+            required_role=NamespaceUserRoleInt.MAINTAINER,
             namespace_id=hwm.namespace_id,
         )
         hwm = await unit_of_work.hwm.delete(hwm_id=hwm_id, user=user)

--- a/horizon/backend/api/v1/router/namespaces.py
+++ b/horizon/backend/api/v1/router/namespaces.py
@@ -4,7 +4,7 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from typing_extensions import Annotated
 
-from horizon.backend.db.models import NamespaceUserRole, User
+from horizon.backend.db.models import NamespaceUserRoleInt, User
 from horizon.backend.services import UnitOfWork, current_user
 from horizon.commons.errors import get_error_responses
 from horizon.commons.schemas.v1 import (
@@ -77,7 +77,7 @@ async def update_namespace(
         await unit_of_work.namespace.check_user_permission(
             user_id=user.id,
             namespace_id=namespace_id,
-            required_role=NamespaceUserRole.OWNER,
+            required_role=NamespaceUserRoleInt.OWNER,
         )
         namespace = await unit_of_work.namespace.update(
             namespace_id=namespace_id,
@@ -108,7 +108,7 @@ async def delete_namespace(
         await unit_of_work.namespace.check_user_permission(
             user_id=user.id,
             namespace_id=namespace_id,
-            required_role=NamespaceUserRole.OWNER,
+            required_role=NamespaceUserRoleInt.OWNER,
         )
         hwm_records = await unit_of_work.hwm.paginate(namespace_id=namespace_id, page=1, page_size=1)
         if hwm_records.total_count:

--- a/horizon/backend/api/v1/router/permission.py
+++ b/horizon/backend/api/v1/router/permission.py
@@ -4,10 +4,14 @@
 from fastapi import APIRouter, Depends
 from typing_extensions import Annotated
 
-from horizon.backend.db.models import User
+from horizon.backend.db.models import NamespaceUserRole, User
 from horizon.backend.services import UnitOfWork, current_user
 from horizon.commons.errors import get_error_responses
-from horizon.commons.schemas.v1 import PermissionResponseItemV1, PermissionsResponseV1
+from horizon.commons.schemas.v1 import (
+    PermissionResponseItemV1,
+    PermissionsResponseV1,
+    PermissionsUpdateRequestV1,
+)
 
 router = APIRouter(prefix="/namespace", tags=["Permissions"], responses=get_error_responses())
 
@@ -18,5 +22,39 @@ async def get_namespace_permissions(
     unit_of_work: Annotated[UnitOfWork, Depends()],
     user: Annotated[User, Depends(current_user)],
 ) -> PermissionsResponseV1:
-    permissions = await unit_of_work.namespace.get_permissions(namespace_id)
+    async with unit_of_work:
+        await unit_of_work.namespace.check_user_permission(
+            user_id=user.id,
+            namespace_id=namespace_id,
+            required_role=NamespaceUserRole.OWNER,
+        )
+        permissions = await unit_of_work.namespace.get_permissions(namespace_id)
     return PermissionsResponseV1(permissions=[PermissionResponseItemV1(**perm) for perm in permissions])
+
+
+@router.patch(
+    "/{namespace_id}/permissions",
+    summary="Update namespace permissions",
+    dependencies=[Depends(current_user)],
+)
+async def update_namespace_permissions(
+    namespace_id: int,
+    changes: PermissionsUpdateRequestV1,
+    unit_of_work: Annotated[UnitOfWork, Depends()],
+    user: Annotated[User, Depends(current_user)],
+) -> PermissionsResponseV1:
+    async with unit_of_work:
+        await unit_of_work.namespace.check_user_permission(
+            user_id=user.id,
+            namespace_id=namespace_id,
+            required_role=NamespaceUserRole.OWNER,
+        )
+        updated_permissions = await unit_of_work.namespace.update_permissions(
+            namespace_id=namespace_id,
+            permissions_update=changes,
+        )
+    return PermissionsResponseV1(
+        permissions=[
+            PermissionResponseItemV1(username=perm["username"], role=perm["role"]) for perm in updated_permissions
+        ],
+    )

--- a/horizon/backend/api/v1/router/permission.py
+++ b/horizon/backend/api/v1/router/permission.py
@@ -28,7 +28,7 @@ async def get_namespace_permissions(
             namespace_id=namespace_id,
             required_role=NamespaceUserRole.OWNER,
         )
-        permissions = await unit_of_work.namespace.get_permissions(namespace_id)
+        permissions = await unit_of_work.namespace.get_namespace_users_permissions(namespace_id)
     return PermissionsResponseV1(permissions=[PermissionResponseItemV1(**perm) for perm in permissions])
 
 
@@ -49,13 +49,14 @@ async def update_namespace_permissions(
             namespace_id=namespace_id,
             required_role=NamespaceUserRole.OWNER,
         )
-        updated_permissions = await unit_of_work.namespace.update_permissions(
+        updated_permissions = await unit_of_work.namespace.update_namespace_users_permissions(
             namespace_id=namespace_id,
             owner_id=user.id,
             permissions_update=changes,
         )
     return PermissionsResponseV1(
         permissions=[
-            PermissionResponseItemV1(username=perm["username"], role=perm["role"]) for perm in updated_permissions
+            PermissionResponseItemV1(username=permission["username"], role=permission["role"])
+            for permission in updated_permissions
         ],
     )

--- a/horizon/backend/api/v1/router/permission.py
+++ b/horizon/backend/api/v1/router/permission.py
@@ -6,7 +6,7 @@ from typing import Set
 from fastapi import APIRouter, Depends
 from typing_extensions import Annotated
 
-from horizon.backend.db.models import NamespaceUserRole, User
+from horizon.backend.db.models import NamespaceUserRoleInt, User
 from horizon.backend.services import UnitOfWork, current_user
 from horizon.commons.errors import get_error_responses
 from horizon.commons.schemas.v1 import (
@@ -28,7 +28,7 @@ async def get_namespace_permissions(
         await unit_of_work.namespace.check_user_permission(
             user_id=user.id,
             namespace_id=namespace_id,
-            required_role=NamespaceUserRole.OWNER,
+            required_role=NamespaceUserRoleInt.OWNER,
         )
         permissions_dict = await unit_of_work.namespace.get_namespace_users_permissions(namespace_id)
 
@@ -54,12 +54,12 @@ async def update_namespace_permissions(
         await unit_of_work.namespace.check_user_permission(
             user_id=user.id,
             namespace_id=namespace_id,
-            required_role=NamespaceUserRole.OWNER,
+            required_role=NamespaceUserRoleInt.OWNER,
         )
 
         sorted_permissions = sorted(
             changes.permissions,
-            key=lambda perm: perm.role == NamespaceUserRole.OWNER.name if perm.role else False,
+            key=lambda perm: perm.role == NamespaceUserRoleInt.OWNER.name if perm.role else False,
             reverse=True,
         )
 
@@ -70,7 +70,7 @@ async def update_namespace_permissions(
             perm_user = await unit_of_work.user.get_user_by_username(permission.username)
 
             if permission.role:
-                role_enum = NamespaceUserRole[permission.role.upper()]
+                role_enum = NamespaceUserRoleInt[permission.role.upper()]
                 await unit_of_work.namespace.update_user_permission(
                     namespace_id,
                     perm_user.id,

--- a/horizon/backend/api/v1/router/permission.py
+++ b/horizon/backend/api/v1/router/permission.py
@@ -51,6 +51,7 @@ async def update_namespace_permissions(
         )
         updated_permissions = await unit_of_work.namespace.update_permissions(
             namespace_id=namespace_id,
+            owner_id=user.id,
             permissions_update=changes,
         )
     return PermissionsResponseV1(

--- a/horizon/backend/api/v1/router/permission.py
+++ b/horizon/backend/api/v1/router/permission.py
@@ -30,8 +30,13 @@ async def get_namespace_permissions(
             namespace_id=namespace_id,
             required_role=NamespaceUserRole.OWNER,
         )
-        permissions = await unit_of_work.namespace.get_namespace_users_permissions(namespace_id)
-    return PermissionsResponseV1(permissions=[PermissionResponseItemV1(**perm) for perm in permissions])
+        permissions_dict = await unit_of_work.namespace.get_namespace_users_permissions(namespace_id)
+
+        permissions_response = [
+            PermissionResponseItemV1(username=user.username, role=role.name) for user, role in permissions_dict.items()
+        ]
+
+    return PermissionsResponseV1(permissions=permissions_response)
 
 
 @router.patch(

--- a/horizon/backend/api/v1/router/permission.py
+++ b/horizon/backend/api/v1/router/permission.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2023-2024 MTS (Mobile Telesystems)
+# SPDX-License-Identifier: Apache-2.0
+
+from fastapi import APIRouter, Depends
+from typing_extensions import Annotated
+
+from horizon.backend.db.models import User
+from horizon.backend.services import UnitOfWork, current_user
+from horizon.commons.errors import get_error_responses
+from horizon.commons.schemas.v1 import PermissionResponseItemV1, PermissionsResponseV1
+
+router = APIRouter(prefix="/namespace", tags=["Permissions"], responses=get_error_responses())
+
+
+@router.get("/{namespace_id}/permissions", summary="Get namespace permissions", dependencies=[Depends(current_user)])
+async def get_namespace_permissions(
+    namespace_id: int,
+    unit_of_work: Annotated[UnitOfWork, Depends()],
+    user: Annotated[User, Depends(current_user)],
+) -> PermissionsResponseV1:
+    permissions = await unit_of_work.namespace.get_permissions(namespace_id)
+    return PermissionsResponseV1(permissions=[PermissionResponseItemV1(**perm) for perm in permissions])

--- a/horizon/backend/db/models/__init__.py
+++ b/horizon/backend/db/models/__init__.py
@@ -4,7 +4,11 @@ from horizon.backend.db.models.base import Base
 from horizon.backend.db.models.credentials_cache import CredentialsCache
 from horizon.backend.db.models.hwm import HWM
 from horizon.backend.db.models.hwm_history import HWMHistory
-from horizon.backend.db.models.namespace import Namespace, NamespaceUserRole
+from horizon.backend.db.models.namespace import (
+    Namespace,
+    NamespaceUserRoleInt,
+    NamespaceUserRoleStr,
+)
 from horizon.backend.db.models.namespace_history import NamespaceHistory
 from horizon.backend.db.models.namespace_user import NamespaceUser
 from horizon.backend.db.models.user import User

--- a/horizon/backend/db/models/__init__.py
+++ b/horizon/backend/db/models/__init__.py
@@ -4,11 +4,7 @@ from horizon.backend.db.models.base import Base
 from horizon.backend.db.models.credentials_cache import CredentialsCache
 from horizon.backend.db.models.hwm import HWM
 from horizon.backend.db.models.hwm_history import HWMHistory
-from horizon.backend.db.models.namespace import (
-    Namespace,
-    NamespaceUserRoleInt,
-    NamespaceUserRoleStr,
-)
+from horizon.backend.db.models.namespace import Namespace, NamespaceUserRoleInt
 from horizon.backend.db.models.namespace_history import NamespaceHistory
 from horizon.backend.db.models.namespace_user import NamespaceUser
 from horizon.backend.db.models.user import User

--- a/horizon/backend/db/models/namespace.py
+++ b/horizon/backend/db/models/namespace.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2023-2024 MTS (Mobile Telesystems)
 # SPDX-License-Identifier: Apache-2.0
-import enum
+from enum import Enum, IntEnum
 
 from sqlalchemy import BigInteger, ForeignKey, String, Text
 from sqlalchemy.ext.associationproxy import AssociationProxy, association_proxy
@@ -10,11 +10,17 @@ from horizon.backend.db.mixins.changed_by import ChangedByMixin
 from horizon.backend.db.models.base import Base
 
 
-class NamespaceUserRole(enum.IntEnum):
+class NamespaceUserRoleInt(IntEnum):
     GUEST = 0
     DEVELOPER = 1
     MAINTAINER = 2
     OWNER = 3
+
+
+class NamespaceUserRoleStr(str, Enum):  # noqa: WPS60
+    DEVELOPER = "DEVELOPER"
+    MAINTAINER = "MAINTAINER"
+    OWNER = "OWNER"
 
 
 class Namespace(Base, ChangedByMixin):

--- a/horizon/backend/db/models/namespace.py
+++ b/horizon/backend/db/models/namespace.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2023-2024 MTS (Mobile Telesystems)
 # SPDX-License-Identifier: Apache-2.0
-from enum import Enum, IntEnum
+from enum import IntEnum
 
 from sqlalchemy import BigInteger, ForeignKey, String, Text
 from sqlalchemy.ext.associationproxy import AssociationProxy, association_proxy
@@ -15,12 +15,6 @@ class NamespaceUserRoleInt(IntEnum):
     DEVELOPER = 1
     MAINTAINER = 2
     OWNER = 3
-
-
-class NamespaceUserRoleStr(str, Enum):  # noqa: WPS60
-    DEVELOPER = "DEVELOPER"
-    MAINTAINER = "MAINTAINER"
-    OWNER = "OWNER"
 
 
 class Namespace(Base, ChangedByMixin):

--- a/horizon/backend/db/repositories/namespace.py
+++ b/horizon/backend/db/repositories/namespace.py
@@ -176,7 +176,7 @@ class NamespaceRepository(Repository[Namespace]):
                     # without reassigning new OWNER to namespace
                     # TODO: create custom exception if logic is acceptable
                     raise HTTPException(
-                        status_code=status.HTTP_403_FORBIDDEN,
+                        status_code=status.HTTP_400_BAD_REQUEST,
                         detail="Operation forbidden: The current owner cannot change their rights"
                         " without reassigning them to another user.",
                     )

--- a/horizon/backend/db/repositories/namespace.py
+++ b/horizon/backend/db/repositories/namespace.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Dict
+from typing import Dict, cast
 
 from sqlalchemy import SQLColumnExpression, delete, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -133,6 +133,7 @@ class NamespaceRepository(Repository[Namespace]):
 
         namespace = await self.get(namespace_id)
         owner = await self._session.get(User, namespace.owner_id)
+        owner = cast(User, owner)
         permissions_dict[owner] = NamespaceUserRoleInt.OWNER
 
         query = (
@@ -144,7 +145,7 @@ class NamespaceRepository(Repository[Namespace]):
         for user, role in result.fetchall():
             permissions_dict[user] = NamespaceUserRoleInt[role]
 
-        return permissions_dict  # type: ignore
+        return permissions_dict
 
     async def set_new_owner(self, namespace_id: int, new_owner_id: int) -> None:
         await self._session.execute(update(Namespace).where(Namespace.id == namespace_id).values(owner_id=new_owner_id))

--- a/horizon/backend/db/repositories/user.py
+++ b/horizon/backend/db/repositories/user.py
@@ -21,6 +21,12 @@ class UserRepository(Repository[User]):
             raise EntityNotFoundError("User", "id", user_id)
         return result
 
+    async def get_user_by_username(self, username: str) -> User:
+        user = await self._get(User.username == username)
+        if not user:
+            raise EntityNotFoundError("User", "username", username)
+        return user
+
     async def create(
         self,
         username: str,

--- a/horizon/backend/db/repositories/user.py
+++ b/horizon/backend/db/repositories/user.py
@@ -21,7 +21,7 @@ class UserRepository(Repository[User]):
             raise EntityNotFoundError("User", "id", user_id)
         return result
 
-    async def get_user_by_username(self, username: str) -> User:
+    async def get_by_username(self, username: str) -> User:
         user = await self._get(User.username == username)
         if not user:
             raise EntityNotFoundError("User", "username", username)

--- a/horizon/client/sync.py
+++ b/horizon/client/sync.py
@@ -26,6 +26,8 @@ from horizon.commons.schemas.v1 import (
     NamespaceResponseV1,
     NamespaceUpdateRequestV1,
     PageResponseV1,
+    PermissionsResponseV1,
+    PermissionsUpdateRequestV1,
     UserResponseV1,
 )
 
@@ -744,6 +746,82 @@ class HorizonClientSync(BaseClient[OAuth2Session]):
         self._request(
             "DELETE",
             f"{self.base_url}/v1/hwm/{hwm_id}",
+        )
+
+    def get_namespace_permissions(self, namespace_id: int) -> PermissionsResponseV1:
+        """Get permissions for a namespace.
+
+        Parameters
+        ----------
+        namespace_id : int
+            The ID of the namespace to get permissions for.
+
+        Returns
+        -------
+        :obj:`PermissionsResponseV1 <horizon.commons.schemas.v1.permission.PermissionsResponseV1>`
+            The permissions of the namespace.
+
+        Raises
+        ------
+        :obj:`EntityNotFoundError <horizon.commons.exceptions.entity.EntityNotFoundError>`
+            Namespace or provided user not found.
+        :obj:`PermissionDeniedError <horizon.commons.exceptions.permission.PermissionDeniedError>`
+            Permission denied for performing the requested action.
+
+            TODO: add "bad_request" error
+
+        Examples
+        --------
+
+        >>> client.get_namespace_permissions(namespace_id=234)
+        """
+
+        return self._request(  # type: ignore[return-value]
+            "GET",
+            f"{self.base_url}/v1/namespace/{namespace_id}/permissions",
+            response_class=PermissionsResponseV1,
+        )
+
+    def update_namespace_permissions(
+        self,
+        namespace_id: int,
+        changes: PermissionsUpdateRequestV1,
+    ) -> PermissionsResponseV1:
+        """Update permissions for a namespace.
+
+        Parameters
+        ----------
+        namespace_id : int
+            The ID of the namespace to update permissions for.
+        changes : :obj:`PermissionsUpdateRequestV1 <horizon.commons.schemas.v1.permission.PermissionsUpdateRequestV1>`
+            The changes to apply to the namespace's permissions.
+
+        Returns
+        -------
+        :obj:`PermissionsResponseV1 <horizon.commons.schemas.v1.permission.PermissionsResponseV1>`
+            The permissions of the namespace.
+
+        Raises
+        ------
+        :obj:`EntityNotFoundError <horizon.commons.exceptions.entity.EntityNotFoundError>`
+            Namespace or provided user not found.
+        :obj:`PermissionDeniedError <horizon.commons.exceptions.permission.PermissionDeniedError>`
+            Permission denied for performing the requested action.
+
+            TODO: add "bad_request" error
+
+        Examples
+        --------
+
+        >>> from horizon.commons.schemas.v1 import PermissionsUpdateRequestV1
+        >>> to_update = PermissionsUpdateRequestV1([{'role': 'OWNER', 'username': 'needed_user'}])
+        >>> client.update_namespace_permissions(namespace_id=234, changes=to_update)
+        """
+        return self._request(  # type: ignore[return-value]
+            "PATCH",
+            f"{self.base_url}/v1/namespace/{namespace_id}/permissions",
+            json=changes.dict(exclude_unset=True),
+            response_class=PermissionsResponseV1,
         )
 
     def paginate_hwm_history(

--- a/horizon/client/sync.py
+++ b/horizon/client/sync.py
@@ -811,8 +811,8 @@ class HorizonClientSync(BaseClient[OAuth2Session]):
         Examples
         --------
 
-        >>> from horizon.commons.schemas.v1 import PermissionsUpdateRequestV1
-        >>> to_update = PermissionsUpdateRequestV1([{'role': 'OWNER', 'username': 'needed_user'}])
+        >>> from horizon.commons.schemas.v1 import PermissionsUpdateRequestV1, PermissionUpdateRequestItemV1
+        >>> to_update = PermissionsUpdateRequestV1([PermissionUpdateRequestItemV1(role="OWNER", username="needed_user")])
         >>> client.update_namespace_permissions(namespace_id=234, changes=to_update)
         """
         return self._request(  # type: ignore[return-value]

--- a/horizon/client/sync.py
+++ b/horizon/client/sync.py
@@ -768,8 +768,6 @@ class HorizonClientSync(BaseClient[OAuth2Session]):
         :obj:`PermissionDeniedError <horizon.commons.exceptions.permission.PermissionDeniedError>`
             Permission denied for performing the requested action.
 
-            TODO: add "bad_request" error
-
         Examples
         --------
 
@@ -807,8 +805,8 @@ class HorizonClientSync(BaseClient[OAuth2Session]):
             Namespace or provided user not found.
         :obj:`PermissionDeniedError <horizon.commons.exceptions.permission.PermissionDeniedError>`
             Permission denied for performing the requested action.
-
-            TODO: add "bad_request" error
+        :obj:`BadRequestError <horizon.commons.exceptions.permission.BadRequestError>`
+            Bad request with incorrect operating logic.
 
         Examples
         --------

--- a/horizon/commons/errors/schemas/__init__.py
+++ b/horizon/commons/errors/schemas/__init__.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2023-2024 MTS (Mobile Telesystems)
 # SPDX-License-Identifier: Apache-2.0
 from horizon.commons.errors.schemas.already_exists import AlreadyExistsSchema
+from horizon.commons.errors.schemas.bad_request import BadRequestError
 from horizon.commons.errors.schemas.invalid_request import InvalidRequestSchema
 from horizon.commons.errors.schemas.not_authorized import NotAuthorizedSchema
 from horizon.commons.errors.schemas.not_found import NotFoundSchema
@@ -11,4 +12,5 @@ __all__ = [
     "InvalidRequestSchema",
     "NotAuthorizedSchema",
     "NotFoundSchema",
+    "BadRequestError",
 ]

--- a/horizon/commons/errors/schemas/bad_request.py
+++ b/horizon/commons/errors/schemas/bad_request.py
@@ -2,16 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 import http
 
-from pydantic import BaseModel
 from typing_extensions import Literal
 
 from horizon.commons.errors.base import BaseErrorSchema
 from horizon.commons.errors.registration import register_error_response
 from horizon.commons.exceptions import BadRequestError
-
-
-class BadRequestDetailsSchema(BaseModel):
-    reason: str
 
 
 @register_error_response(
@@ -20,7 +15,3 @@ class BadRequestDetailsSchema(BaseModel):
 )
 class BadRequestSchema(BaseErrorSchema):
     code: Literal["bad_request"] = "bad_request"
-    details: BadRequestDetailsSchema
-
-    def to_exception(self) -> BadRequestError:
-        return BadRequestError(reason=self.details.reason)

--- a/horizon/commons/errors/schemas/bad_request.py
+++ b/horizon/commons/errors/schemas/bad_request.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2023-2024 MTS (Mobile Telesystems)
+# SPDX-License-Identifier: Apache-2.0
+import http
+
+from pydantic import BaseModel
+from typing_extensions import Literal
+
+from horizon.commons.errors.base import BaseErrorSchema
+from horizon.commons.errors.registration import register_error_response
+from horizon.commons.exceptions import BadRequestError
+
+
+class BadRequestDetailsSchema(BaseModel):
+    reason: str
+
+
+@register_error_response(
+    exception=BadRequestError,
+    status=http.HTTPStatus.BAD_REQUEST,
+)
+class BadRequestSchema(BaseErrorSchema):
+    code: Literal["bad_request"] = "bad_request"
+    details: BadRequestDetailsSchema
+
+    def to_exception(self) -> BadRequestError:
+        return BadRequestError(reason=self.details.reason)

--- a/horizon/commons/exceptions/__init__.py
+++ b/horizon/commons/exceptions/__init__.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from horizon.commons.exceptions.auth import AuthorizationError
+from horizon.commons.exceptions.bad_request import BadRequestError
 from horizon.commons.exceptions.base import ApplicationError
 from horizon.commons.exceptions.entity import (
     EntityAlreadyExistsError,
@@ -15,6 +16,7 @@ __all__ = [
     "ApplicationError",
     "EntityAlreadyExistsError",
     "PermissionDeniedError",
+    "BadRequestError",
     "EntityNotFoundError",
     "ServiceError",
 ]

--- a/horizon/commons/exceptions/bad_request.py
+++ b/horizon/commons/exceptions/bad_request.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2023-2024 MTS (Mobile Telesystems)
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from horizon.commons.exceptions.base import ApplicationError
+
+
+class BadRequestError(ApplicationError):
+    """Bad request error.
+
+    This exception should be raised when a request cannot be processed due to
+    client-side errors (e.g., invalid data, duplicate entries).
+
+    Examples
+    --------
+
+    >>> from horizon.commons.exceptions import BadRequestError
+    >>> raise BadRequestError("Duplicate username detected. Each username must appear only once.")
+    Traceback (most recent call last):
+    horizon.commons.exceptions.BadRequestError: Duplicate username detected. Each username must appear only once.
+    """
+
+    reason: str
+    """Bad request reason message"""
+
+    def __init__(self, reason: str):
+        self.reason = reason
+
+    @property
+    def message(self) -> str:
+        return self.reason
+
+    @property
+    def details(self) -> dict[str, str]:
+        return {"reason": self.reason}

--- a/horizon/commons/exceptions/bad_request.py
+++ b/horizon/commons/exceptions/bad_request.py
@@ -31,5 +31,5 @@ class BadRequestError(ApplicationError):
         return self.reason
 
     @property
-    def details(self) -> dict[str, str]:
-        return {"reason": self.reason}
+    def details(self) -> dict:
+        return {}

--- a/horizon/commons/exceptions/permission.py
+++ b/horizon/commons/exceptions/permission.py
@@ -15,8 +15,8 @@ class PermissionDeniedError(ApplicationError):
     --------
 
     >>> from horizon.commons.exceptions import PermissionDeniedError
-    >>> from horizon.backend.db.models import NamespaceUserRole
-    >>> raise PermissionDeniedError(required_role=NamespaceUserRole.DEVELOPER.name, actual_role=NamespaceUserRole.GUEST.name)
+    >>> from horizon.backend.db.models import NamespaceUserRoleInt
+    >>> raise PermissionDeniedError(required_role=NamespaceUserRoleInt.DEVELOPER.name, actual_role=NamespaceUserRoleInt.GUEST.name)
     Traceback (most recent call last):
     horizon.commons.exceptions.PermissionDeniedError: Permission denied. User has role GUEST but action requires at least DEVELOPER.
     """

--- a/horizon/commons/exceptions/permission.py
+++ b/horizon/commons/exceptions/permission.py
@@ -15,8 +15,7 @@ class PermissionDeniedError(ApplicationError):
     --------
 
     >>> from horizon.commons.exceptions import PermissionDeniedError
-    >>> from horizon.backend.db.models import NamespaceUserRoleInt
-    >>> raise PermissionDeniedError(required_role=NamespaceUserRoleInt.DEVELOPER.name, actual_role=NamespaceUserRoleInt.GUEST.name)
+    >>> raise PermissionDeniedError(required_role="DEVELOPER", actual_role="GUEST")
     Traceback (most recent call last):
     horizon.commons.exceptions.PermissionDeniedError: Permission denied. User has role GUEST but action requires at least DEVELOPER.
     """

--- a/horizon/commons/schemas/v1/__init__.py
+++ b/horizon/commons/schemas/v1/__init__.py
@@ -26,6 +26,12 @@ from horizon.commons.schemas.v1.pagination import (
     PageResponseV1,
     PaginateQueryV1,
 )
+from horizon.commons.schemas.v1.permission import (
+    PermissionResponseItemV1,
+    PermissionsRequestItemV1,
+    PermissionsRequestV1,
+    PermissionsResponseV1,
+)
 from horizon.commons.schemas.v1.user import UserResponseV1
 
 __all__ = [
@@ -45,5 +51,9 @@ __all__ = [
     "PageMetaResponseV1",
     "PageResponseV1",
     "PaginateQueryV1",
+    "PermissionsRequestItemV1",
+    "PermissionResponseItemV1",
+    "PermissionsResponseV1",
+    "PermissionsRequestV1",
     "UserResponseV1",
 ]

--- a/horizon/commons/schemas/v1/__init__.py
+++ b/horizon/commons/schemas/v1/__init__.py
@@ -28,9 +28,9 @@ from horizon.commons.schemas.v1.pagination import (
 )
 from horizon.commons.schemas.v1.permission import (
     PermissionResponseItemV1,
-    PermissionsRequestItemV1,
-    PermissionsRequestV1,
     PermissionsResponseV1,
+    PermissionsUpdateRequestV1,
+    PermissionUpdateRequestItemV1,
 )
 from horizon.commons.schemas.v1.user import UserResponseV1
 
@@ -51,9 +51,9 @@ __all__ = [
     "PageMetaResponseV1",
     "PageResponseV1",
     "PaginateQueryV1",
-    "PermissionsRequestItemV1",
+    "PermissionUpdateRequestItemV1",
     "PermissionResponseItemV1",
     "PermissionsResponseV1",
-    "PermissionsRequestV1",
+    "PermissionsUpdateRequestV1",
     "UserResponseV1",
 ]

--- a/horizon/commons/schemas/v1/__init__.py
+++ b/horizon/commons/schemas/v1/__init__.py
@@ -16,6 +16,7 @@ from horizon.commons.schemas.v1.namespace import (
     NamespacePaginateQueryV1,
     NamespaceResponseV1,
     NamespaceUpdateRequestV1,
+    NamespaceUserRole,
 )
 from horizon.commons.schemas.v1.namespace_history import (
     NamespaceHistoryPaginateQueryV1,

--- a/horizon/commons/schemas/v1/namespace.py
+++ b/horizon/commons/schemas/v1/namespace.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2023-2024 MTS (Mobile Telesystems)
 # SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
+from enum import Enum
 from typing import Optional, Union
 
 from pydantic import BaseModel, Field, root_validator
@@ -9,6 +10,12 @@ from horizon.commons.dto import Unset
 from horizon.commons.schemas.v1.pagination import PaginateQueryV1
 
 MAX_NAME_LENGTH = 256
+
+
+class NamespaceUserRole(str, Enum):  # noqa: WPS60
+    DEVELOPER = "DEVELOPER"
+    MAINTAINER = "MAINTAINER"
+    OWNER = "OWNER"
 
 
 class NamespaceResponseV1(BaseModel):

--- a/horizon/commons/schemas/v1/permission.py
+++ b/horizon/commons/schemas/v1/permission.py
@@ -18,7 +18,7 @@ class PermissionsResponseV1(BaseModel):
     permissions: List[PermissionResponseItemV1]
 
 
-class PermissionsRequestItemV1(BaseModel):
+class PermissionUpdateRequestItemV1(BaseModel):
     """Represents a single permission entry in a request, specifying a desired role for a user within a namespace."""
 
     username: str
@@ -29,10 +29,10 @@ class PermissionsRequestItemV1(BaseModel):
     )
 
 
-class PermissionsRequestV1(BaseModel):
+class PermissionsUpdateRequestV1(BaseModel):
     """Wraps a list of permission modification requests for a namespace, used by the PATCH endpoint."""
 
-    permissions: List[PermissionsRequestItemV1] = Field(
+    permissions: List[PermissionUpdateRequestItemV1] = Field(
         description="A list of modifications to the namespace's permissions."
         " Each entry specifies a user and the role they should have or be removed from.",
     )

--- a/horizon/commons/schemas/v1/permission.py
+++ b/horizon/commons/schemas/v1/permission.py
@@ -4,12 +4,14 @@ from typing import List, Optional
 
 from pydantic import BaseModel, Field
 
+from horizon.backend.db.models import NamespaceUserRoleStr
+
 
 class PermissionResponseItemV1(BaseModel):
     """Represents a single permission entry in a response, linking a user with their role within a namespace."""
 
     username: str
-    role: str
+    role: NamespaceUserRoleStr
 
 
 class PermissionsResponseV1(BaseModel):
@@ -22,7 +24,7 @@ class PermissionUpdateRequestItemV1(BaseModel):
     """Represents a single permission entry in a request, specifying a desired role for a user within a namespace."""
 
     username: str
-    role: Optional[str] = Field(
+    role: Optional[NamespaceUserRoleStr] = Field(
         default=None,
         description="The role to be assigned to the user within the namespace."
         " A value of `None` indicates that the permission should be removed.",

--- a/horizon/commons/schemas/v1/permission.py
+++ b/horizon/commons/schemas/v1/permission.py
@@ -44,8 +44,7 @@ class PermissionsUpdateRequestV1(BaseModel):
         seen: Set[str] = set()
         owner_count = 0
         for perm in permissions:
-            username = perm.username if hasattr(perm, "username") else perm.get("username")
-            role = perm.role if hasattr(perm, "role") else perm.get("role")
+            username, role = perm.username, perm.role
 
             if username in seen:
                 raise ValueError(f"Duplicate username detected: {username}. Each username must appear only once.")

--- a/horizon/commons/schemas/v1/permission.py
+++ b/horizon/commons/schemas/v1/permission.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2023-2024 MTS (Mobile Telesystems)
+# SPDX-License-Identifier: Apache-2.0
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class PermissionResponseItemV1(BaseModel):
+    """Represents a single permission entry in a response, linking a user with their role within a namespace."""
+
+    username: str
+    role: str
+
+
+class PermissionsResponseV1(BaseModel):
+    """Wraps a list of permission entries for a namespace, returned by the GET endpoint."""
+
+    permissions: List[PermissionResponseItemV1]
+
+
+class PermissionsRequestItemV1(BaseModel):
+    """Represents a single permission entry in a request, specifying a desired role for a user within a namespace."""
+
+    username: str
+    role: Optional[str] = Field(
+        default=None,
+        description="The role to be assigned to the user within the namespace."
+        " A value of `None` indicates that the permission should be removed.",
+    )
+
+
+class PermissionsRequestV1(BaseModel):
+    """Wraps a list of permission modification requests for a namespace, used by the PATCH endpoint."""
+
+    permissions: List[PermissionsRequestItemV1] = Field(
+        description="A list of modifications to the namespace's permissions."
+        " Each entry specifies a user and the role they should have or be removed from.",
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,4 +17,5 @@ pytest_plugins = [
     "tests.factories.namespace_history",
     "tests.factories.hwm",
     "tests.factories.hwm_history",
+    "tests.factories.permissions",
 ]

--- a/tests/factories/permissions.py
+++ b/tests/factories/permissions.py
@@ -10,7 +10,12 @@ import pytest_asyncio
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from horizon.backend.db.models import Namespace, NamespaceUser, NamespaceUserRole, User
+from horizon.backend.db.models import (
+    Namespace,
+    NamespaceUser,
+    NamespaceUserRoleInt,
+    User,
+)
 
 
 @pytest_asyncio.fixture
@@ -30,8 +35,8 @@ async def namespace_with_users(
             await async_session.commit()
             created_users.append(user)
 
-            if role != NamespaceUserRole.GUEST:
-                if role == NamespaceUserRole.OWNER:
+            if role != NamespaceUserRoleInt.GUEST:
+                if role == NamespaceUserRoleInt.OWNER:
                     namespace.owner_id = user.id
                 else:
                     namespace_user = NamespaceUser(namespace_id=namespace.id, user_id=user.id, role=role.name)

--- a/tests/factories/permissions.py
+++ b/tests/factories/permissions.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2023 MTS (Mobile Telesystems)
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import AsyncContextManager, Callable
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from horizon.backend.db.models import Namespace, NamespaceUser, NamespaceUserRole, User
+
+
+@pytest_asyncio.fixture
+async def namespace_with_users(
+    request: pytest.FixtureRequest,
+    namespace: Namespace,
+    async_session_factory: Callable[[], AsyncContextManager[AsyncSession]],
+) -> AsyncGenerator[None, None]:
+    users_roles = request.param
+
+    async with async_session_factory() as async_session:
+        created_users = []
+        for username, role in users_roles:
+            user = User(username=username, is_active=True)
+            async_session.add(user)
+            await async_session.commit()
+            created_users.append(user)
+
+            if role != NamespaceUserRole.GUEST:
+                if role == NamespaceUserRole.OWNER:
+                    namespace.owner_id = user.id
+                else:
+                    namespace_user = NamespaceUser(namespace_id=namespace.id, user_id=user.id, role=role.name)
+                    async_session.add(namespace_user)
+
+                await async_session.commit()
+
+    yield
+
+    async with async_session_factory() as async_session:
+        for user in created_users:
+            await async_session.execute(delete(NamespaceUser).where(NamespaceUser.user_id == user.id))
+            await async_session.execute(delete(User).where(User.id == user.id))
+
+        await async_session.commit()

--- a/tests/factories/permissions.py
+++ b/tests/factories/permissions.py
@@ -18,7 +18,13 @@ from horizon.backend.db.models import (
 )
 
 
-@pytest_asyncio.fixture
+@pytest_asyncio.fixture(
+    params=[
+        ("user1", NamespaceUserRoleInt.DEVELOPER),
+        ("user2", NamespaceUserRoleInt.DEVELOPER),
+        ("user3", NamespaceUserRoleInt.MAINTAINER),
+    ]
+)
 async def namespace_with_users(
     request: pytest.FixtureRequest,
     namespace: Namespace,

--- a/tests/factories/user.py
+++ b/tests/factories/user.py
@@ -12,7 +12,12 @@ import pytest_asyncio
 from sqlalchemy import delete, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from horizon.backend.db.models import Namespace, NamespaceUser, NamespaceUserRole, User
+from horizon.backend.db.models import (
+    Namespace,
+    NamespaceUser,
+    NamespaceUserRoleInt,
+    User,
+)
 from tests.factories.base import random_string
 
 
@@ -100,7 +105,7 @@ async def users(
         await async_session.commit()
 
 
-@pytest_asyncio.fixture(params=[NamespaceUserRole.DEVELOPER])
+@pytest_asyncio.fixture(params=[NamespaceUserRoleInt.DEVELOPER])
 async def user_with_role(
     request: pytest.FixtureRequest,
     user: User,
@@ -111,7 +116,7 @@ async def user_with_role(
     fake_owner = None
 
     async with async_session_factory() as async_session:
-        if role != NamespaceUserRole.OWNER:
+        if role != NamespaceUserRoleInt.OWNER:
             fake_owner = User(username=secrets.token_hex(5), is_active=True)
             async_session.add(fake_owner)
             await async_session.commit()
@@ -119,7 +124,7 @@ async def user_with_role(
             namespace.owner_id = fake_owner.id
             async_session.add(namespace)
 
-            if role != NamespaceUserRole.GUEST:
+            if role != NamespaceUserRoleInt.GUEST:
                 namespace_user = NamespaceUser(namespace_id=namespace.id, user_id=user.id, role=role.name)
                 async_session.add(namespace_user)
 

--- a/tests/test_backend/test_hwm/test_create_hwm.py
+++ b/tests/test_backend/test_hwm/test_create_hwm.py
@@ -15,7 +15,7 @@ from horizon.backend.db.models import (
     HWM,
     HWMHistory,
     Namespace,
-    NamespaceUserRole,
+    NamespaceUserRoleInt,
     User,
 )
 
@@ -97,9 +97,9 @@ async def test_create_hwm_missing_namespace(
 @pytest.mark.parametrize(
     "user_with_role",
     [
-        NamespaceUserRole.OWNER,
-        NamespaceUserRole.MAINTAINER,
-        NamespaceUserRole.DEVELOPER,
+        NamespaceUserRoleInt.OWNER,
+        NamespaceUserRoleInt.MAINTAINER,
+        NamespaceUserRoleInt.DEVELOPER,
     ],
     indirect=["user_with_role"],
 )
@@ -546,7 +546,7 @@ async def test_create_hwm_with_same_name_after_deletion(
     "user_with_role, expected_status, expected_response",
     [
         (
-            NamespaceUserRole.GUEST,
+            NamespaceUserRoleInt.GUEST,
             403,
             {
                 "error": {

--- a/tests/test_backend/test_hwm/test_delete_hwm.py
+++ b/tests/test_backend/test_hwm/test_delete_hwm.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 import pytest
 from sqlalchemy import select
 
-from horizon.backend.db.models import HWM, NamespaceUserRole, User
+from horizon.backend.db.models import HWM, NamespaceUserRoleInt, User
 from horizon.backend.db.models.hwm_history import HWMHistory
 
 if TYPE_CHECKING:
@@ -61,8 +61,8 @@ async def test_delete_hwm_missing(
 @pytest.mark.parametrize(
     "user_with_role",
     [
-        NamespaceUserRole.OWNER,
-        NamespaceUserRole.MAINTAINER,
+        NamespaceUserRoleInt.OWNER,
+        NamespaceUserRoleInt.MAINTAINER,
     ],
     indirect=["user_with_role"],
 )
@@ -109,7 +109,7 @@ async def test_delete_hwm(
     "user_with_role, expected_status, expected_response",
     [
         (
-            NamespaceUserRole.DEVELOPER,
+            NamespaceUserRoleInt.DEVELOPER,
             403,
             {
                 "error": {
@@ -123,7 +123,7 @@ async def test_delete_hwm(
             },
         ),
         (
-            NamespaceUserRole.GUEST,
+            NamespaceUserRoleInt.GUEST,
             403,
             {
                 "error": {

--- a/tests/test_backend/test_hwm/test_update_hwm.py
+++ b/tests/test_backend/test_hwm/test_update_hwm.py
@@ -14,7 +14,7 @@ from horizon.backend.db.models import (
     HWM,
     HWMHistory,
     Namespace,
-    NamespaceUserRole,
+    NamespaceUserRoleInt,
     User,
 )
 
@@ -82,9 +82,9 @@ async def test_update_hwm_missing(
 @pytest.mark.parametrize(
     "user_with_role",
     [
-        NamespaceUserRole.OWNER,
-        NamespaceUserRole.MAINTAINER,
-        NamespaceUserRole.DEVELOPER,
+        NamespaceUserRoleInt.OWNER,
+        NamespaceUserRoleInt.MAINTAINER,
+        NamespaceUserRoleInt.DEVELOPER,
     ],
     indirect=["user_with_role"],
 )
@@ -503,7 +503,7 @@ async def test_update_hwm_invalid_field_length(
     "user_with_role, expected_status, expected_response",
     [
         (
-            NamespaceUserRole.GUEST,
+            NamespaceUserRoleInt.GUEST,
             403,
             {
                 "error": {

--- a/tests/test_backend/test_namespace/test_delete_namespace.py
+++ b/tests/test_backend/test_namespace/test_delete_namespace.py
@@ -12,7 +12,7 @@ from horizon.backend.db.models import (
     HWM,
     Namespace,
     NamespaceHistory,
-    NamespaceUserRole,
+    NamespaceUserRoleInt,
     User,
 )
 
@@ -66,7 +66,7 @@ async def test_delete_namespace_missing(
 @pytest.mark.parametrize(
     "user_with_role",
     [
-        NamespaceUserRole.OWNER,
+        NamespaceUserRoleInt.OWNER,
     ],
     indirect=["user_with_role"],
 )
@@ -165,7 +165,7 @@ async def test_delete_namespace_with_existing_hwm(
     "user_with_role, expected_status, expected_response",
     [
         (
-            NamespaceUserRole.MAINTAINER,
+            NamespaceUserRoleInt.MAINTAINER,
             403,
             {
                 "error": {
@@ -179,7 +179,7 @@ async def test_delete_namespace_with_existing_hwm(
             },
         ),
         (
-            NamespaceUserRole.DEVELOPER,
+            NamespaceUserRoleInt.DEVELOPER,
             403,
             {
                 "error": {
@@ -193,7 +193,7 @@ async def test_delete_namespace_with_existing_hwm(
             },
         ),
         (
-            NamespaceUserRole.GUEST,
+            NamespaceUserRoleInt.GUEST,
             403,
             {
                 "error": {

--- a/tests/test_backend/test_namespace/test_update_namespace.py
+++ b/tests/test_backend/test_namespace/test_update_namespace.py
@@ -14,7 +14,7 @@ from sqlalchemy_utils.functions import naturally_equivalent
 from horizon.backend.db.models import (
     Namespace,
     NamespaceHistory,
-    NamespaceUserRole,
+    NamespaceUserRoleInt,
     User,
 )
 
@@ -132,7 +132,7 @@ async def test_update_namespace_name(
 @pytest.mark.parametrize(
     "user_with_role",
     [
-        NamespaceUserRole.OWNER,
+        NamespaceUserRoleInt.OWNER,
     ],
     indirect=["user_with_role"],
 )
@@ -369,7 +369,7 @@ async def test_update_namespace_invalid_name_length(
     "user_with_role, expected_status, expected_response",
     [
         (
-            NamespaceUserRole.MAINTAINER,
+            NamespaceUserRoleInt.MAINTAINER,
             403,
             {
                 "error": {
@@ -383,7 +383,7 @@ async def test_update_namespace_invalid_name_length(
             },
         ),
         (
-            NamespaceUserRole.DEVELOPER,
+            NamespaceUserRoleInt.DEVELOPER,
             403,
             {
                 "error": {
@@ -397,7 +397,7 @@ async def test_update_namespace_invalid_name_length(
             },
         ),
         (
-            NamespaceUserRole.GUEST,
+            NamespaceUserRoleInt.GUEST,
             403,
             {
                 "error": {

--- a/tests/test_backend/test_permissions/test_get_permissions.py
+++ b/tests/test_backend/test_permissions/test_get_permissions.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: 2023 MTS (Mobile Telesystems)
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from horizon.backend.db.models import Namespace, NamespaceUserRole, User
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient
+
+pytestmark = [pytest.mark.backend, pytest.mark.asyncio]
+
+
+async def test_get_namespace_permissions_unauthorized_user(
+    test_client: AsyncClient,
+    namespace: Namespace,
+):
+    response = await test_client.get(
+        f"/v1/namespace/{namespace.id}/permissions",
+    )
+    assert response.status_code == 401
+    assert response.json() == {
+        "error": {
+            "code": "unauthorized",
+            "message": "Not authenticated",
+            "details": None,
+        },
+    }
+
+
+async def test_get_namespace_permissions_missing(
+    test_client: AsyncClient,
+    access_token: str,
+    new_namespace: Namespace,
+):
+    response = await test_client.get(
+        f"/v1/namespace/{new_namespace.id}/permissions",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert response.status_code == 404
+    assert response.json() == {
+        "error": {
+            "code": "not_found",
+            "message": f"Namespace with id={new_namespace.id!r} not found",
+            "details": {
+                "entity_type": "Namespace",
+                "field": "id",
+                "value": new_namespace.id,
+            },
+        },
+    }
+
+
+@pytest.mark.parametrize("user_with_role", [NamespaceUserRole.OWNER], indirect=["user_with_role"])
+@pytest.mark.parametrize(
+    "namespace_with_users",
+    [
+        [
+            ("user1", NamespaceUserRole.DEVELOPER),
+            ("user2", NamespaceUserRole.DEVELOPER),
+            ("user3", NamespaceUserRole.MAINTAINER),
+        ]
+    ],
+    indirect=["namespace_with_users"],
+)
+async def test_get_namespace_permissions(
+    test_client: AsyncClient,
+    access_token: str,
+    user_with_role: None,
+    namespace_with_users: None,
+    user: User,
+    namespace: Namespace,
+):
+    response = await test_client.get(
+        f"/v1/namespace/{namespace.id}/permissions",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert response.status_code == 200
+    permissions = response.json()["permissions"]
+
+    assert permissions == [
+        {"username": user.username, "role": "OWNER"},
+        {"username": "user1", "role": "DEVELOPER"},
+        {"username": "user2", "role": "DEVELOPER"},
+        {"username": "user3", "role": "MAINTAINER"},
+    ]
+
+
+@pytest.mark.parametrize(
+    "user_with_role, expected_status, expected_response",
+    [
+        (
+            NamespaceUserRole.MAINTAINER,
+            403,
+            {
+                "error": {
+                    "code": "permission_denied",
+                    "message": f"Permission denied. User has role MAINTAINER but action requires at least OWNER.",
+                    "details": {
+                        "required_role": "OWNER",
+                        "actual_role": "MAINTAINER",
+                    },
+                }
+            },
+        ),
+        (
+            NamespaceUserRole.DEVELOPER,
+            403,
+            {
+                "error": {
+                    "code": "permission_denied",
+                    "message": f"Permission denied. User has role DEVELOPER but action requires at least OWNER.",
+                    "details": {
+                        "required_role": "OWNER",
+                        "actual_role": "DEVELOPER",
+                    },
+                }
+            },
+        ),
+        (
+            NamespaceUserRole.GUEST,
+            403,
+            {
+                "error": {
+                    "code": "permission_denied",
+                    "message": f"Permission denied. User has role GUEST but action requires at least OWNER.",
+                    "details": {
+                        "required_role": "OWNER",
+                        "actual_role": "GUEST",
+                    },
+                }
+            },
+        ),
+    ],
+    indirect=["user_with_role"],
+)
+async def test_get_permissions_denied(
+    namespace: Namespace,
+    user_with_role: None,
+    expected_status: int,
+    expected_response: dict,
+    test_client: AsyncClient,
+    access_token: str,
+):
+    response = await test_client.get(
+        f"v1/namespace/{namespace.id}/permissions",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert response.status_code == expected_status
+    assert response.json() == expected_response

--- a/tests/test_backend/test_permissions/test_get_permissions.py
+++ b/tests/test_backend/test_permissions/test_get_permissions.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from horizon.backend.db.models import Namespace, NamespaceUserRole, User
+from horizon.backend.db.models import Namespace, NamespaceUserRoleInt, User
 
 if TYPE_CHECKING:
     from httpx import AsyncClient
@@ -54,14 +54,14 @@ async def test_get_namespace_permissions_missing(
     }
 
 
-@pytest.mark.parametrize("user_with_role", [NamespaceUserRole.OWNER], indirect=["user_with_role"])
+@pytest.mark.parametrize("user_with_role", [NamespaceUserRoleInt.OWNER], indirect=["user_with_role"])
 @pytest.mark.parametrize(
     "namespace_with_users",
     [
         [
-            ("user1", NamespaceUserRole.DEVELOPER),
-            ("user2", NamespaceUserRole.DEVELOPER),
-            ("user3", NamespaceUserRole.MAINTAINER),
+            ("user1", NamespaceUserRoleInt.DEVELOPER),
+            ("user2", NamespaceUserRoleInt.DEVELOPER),
+            ("user3", NamespaceUserRoleInt.MAINTAINER),
         ]
     ],
     indirect=["namespace_with_users"],
@@ -93,7 +93,7 @@ async def test_get_namespace_permissions(
     "user_with_role, expected_status, expected_response",
     [
         (
-            NamespaceUserRole.MAINTAINER,
+            NamespaceUserRoleInt.MAINTAINER,
             403,
             {
                 "error": {
@@ -107,7 +107,7 @@ async def test_get_namespace_permissions(
             },
         ),
         (
-            NamespaceUserRole.DEVELOPER,
+            NamespaceUserRoleInt.DEVELOPER,
             403,
             {
                 "error": {
@@ -121,7 +121,7 @@ async def test_get_namespace_permissions(
             },
         ),
         (
-            NamespaceUserRole.GUEST,
+            NamespaceUserRoleInt.GUEST,
             403,
             {
                 "error": {

--- a/tests/test_backend/test_permissions/test_update_permissions.py
+++ b/tests/test_backend/test_permissions/test_update_permissions.py
@@ -100,8 +100,8 @@ async def test_update_namespace_permissions_with_duplicates_usernames(
     assert response.json() == {
         "error": {
             "code": "bad_request",
-            "message": "Duplicate username detected: user1. Each username must appear only once.",
-            "details": {"reason": "Duplicate username detected: user1. Each username must appear only once."},
+            "message": "Duplicate username detected. Each username must appear only once.",
+            "details": {},
         },
     }
 
@@ -140,7 +140,7 @@ async def test_update_namespace_permissions_duplicates_owner(
         "error": {
             "code": "bad_request",
             "message": "Multiple owner role assignments detected. Only one owner can be assigned.",
-            "details": {"reason": "Multiple owner role assignments detected. Only one owner can be assigned."},
+            "details": {},
         },
     }
 
@@ -179,10 +179,7 @@ async def test_update_namespace_permissions_lose_owner(
             "code": "bad_request",
             "message": "Operation forbidden: The current owner cannot change their "
             "rights without reassigning them to another user.",
-            "details": {
-                "reason": "Operation forbidden: The current owner cannot change their "
-                "rights without reassigning them to another user."
-            },
+            "details": {},
         },
     }
 

--- a/tests/test_backend/test_permissions/test_update_permissions.py
+++ b/tests/test_backend/test_permissions/test_update_permissions.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: 2023 MTS (Mobile Telesystems)
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from horizon.backend.db.models import Namespace, NamespaceUserRole
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient
+
+pytestmark = [pytest.mark.backend, pytest.mark.asyncio]
+
+
+@pytest.mark.parametrize(
+    "user_with_role, expected_status, expected_response",
+    [
+        (
+            NamespaceUserRole.MAINTAINER,
+            403,
+            {
+                "error": {
+                    "code": "permission_denied",
+                    "message": f"Permission denied. User has role MAINTAINER but action requires at least OWNER.",
+                    "details": {
+                        "required_role": "OWNER",
+                        "actual_role": "MAINTAINER",
+                    },
+                }
+            },
+        ),
+        (
+            NamespaceUserRole.DEVELOPER,
+            403,
+            {
+                "error": {
+                    "code": "permission_denied",
+                    "message": f"Permission denied. User has role DEVELOPER but action requires at least OWNER.",
+                    "details": {
+                        "required_role": "OWNER",
+                        "actual_role": "DEVELOPER",
+                    },
+                }
+            },
+        ),
+        (
+            NamespaceUserRole.GUEST,
+            403,
+            {
+                "error": {
+                    "code": "permission_denied",
+                    "message": f"Permission denied. User has role GUEST but action requires at least OWNER.",
+                    "details": {
+                        "required_role": "OWNER",
+                        "actual_role": "GUEST",
+                    },
+                }
+            },
+        ),
+    ],
+    indirect=["user_with_role"],
+)
+async def test_update_permissions_denied(
+    namespace: Namespace,
+    user_with_role: None,
+    expected_status: int,
+    expected_response: dict,
+    test_client: AsyncClient,
+    access_token: str,
+):
+    response = await test_client.get(
+        f"v1/namespace/{namespace.id}/permissions",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert response.status_code == expected_status
+    assert response.json() == expected_response

--- a/tests/test_backend/test_permissions/test_update_permissions.py
+++ b/tests/test_backend/test_permissions/test_update_permissions.py
@@ -96,14 +96,7 @@ async def test_update_namespace_permissions_with_duplicates_usernames(
         headers={"Authorization": f"Bearer {access_token}"},
         json=changes,
     )
-    assert response.status_code == 400
-    assert response.json() == {
-        "error": {
-            "code": "bad_request",
-            "message": "Duplicate username detected. Each username must appear only once.",
-            "details": {},
-        },
-    }
+    assert response.status_code == 422
 
 
 @pytest.mark.parametrize(
@@ -135,14 +128,7 @@ async def test_update_namespace_permissions_duplicates_owner(
         headers={"Authorization": f"Bearer {access_token}"},
         json=changes,
     )
-    assert response.status_code == 400
-    assert response.json() == {
-        "error": {
-            "code": "bad_request",
-            "message": "Multiple owner role assignments detected. Only one owner can be assigned.",
-            "details": {},
-        },
-    }
+    assert response.status_code == 422
 
 
 @pytest.mark.parametrize(

--- a/tests/test_backend/test_permissions/test_update_permissions.py
+++ b/tests/test_backend/test_permissions/test_update_permissions.py
@@ -101,7 +101,7 @@ async def test_update_namespace_permissions_with_duplicates_usernames(
         "error": {
             "code": "bad_request",
             "message": "Duplicate username detected: user1. Each username must appear only once.",
-            "details": None,
+            "details": {"reason": "Duplicate username detected: user1. Each username must appear only once."},
         },
     }
 
@@ -140,7 +140,7 @@ async def test_update_namespace_permissions_duplicates_owner(
         "error": {
             "code": "bad_request",
             "message": "Multiple owner role assignments detected. Only one owner can be assigned.",
-            "details": None,
+            "details": {"reason": "Multiple owner role assignments detected. Only one owner can be assigned."},
         },
     }
 
@@ -179,7 +179,10 @@ async def test_update_namespace_permissions_lose_owner(
             "code": "bad_request",
             "message": "Operation forbidden: The current owner cannot change their "
             "rights without reassigning them to another user.",
-            "details": None,
+            "details": {
+                "reason": "Operation forbidden: The current owner cannot change their "
+                "rights without reassigning them to another user."
+            },
         },
     }
 

--- a/tests/test_backend/test_permissions/test_update_permissions.py
+++ b/tests/test_backend/test_permissions/test_update_permissions.py
@@ -2,16 +2,286 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+import secrets
 from typing import TYPE_CHECKING
 
 import pytest
 
-from horizon.backend.db.models import Namespace, NamespaceUserRole
+from horizon.backend.db.models import Namespace, NamespaceUserRole, User
 
 if TYPE_CHECKING:
     from httpx import AsyncClient
 
 pytestmark = [pytest.mark.backend, pytest.mark.asyncio]
+
+
+async def test_update_namespace_permissions_unauthorized_user(
+    test_client: AsyncClient,
+    namespace: Namespace,
+):
+    changes = {
+        "permissions": [
+            {"username": secrets.token_hex(6), "role": NamespaceUserRole.DEVELOPER.name},
+        ]
+    }
+    response = await test_client.patch(
+        f"/v1/namespace/{namespace.id}/permissions",
+        json=changes,
+    )
+    assert response.status_code == 401
+    assert response.json() == {
+        "error": {
+            "code": "unauthorized",
+            "message": "Not authenticated",
+            "details": None,
+        },
+    }
+
+
+async def test_update_namespace_permissions_namespace_missing(
+    test_client: AsyncClient,
+    access_token: str,
+    new_namespace: Namespace,
+):
+    changes = {
+        "permissions": [
+            {"username": secrets.token_hex(6), "role": NamespaceUserRole.DEVELOPER.name},
+        ]
+    }
+    response = await test_client.patch(
+        f"/v1/namespace/{new_namespace.id}/permissions",
+        headers={"Authorization": f"Bearer {access_token}"},
+        json=changes,
+    )
+    assert response.status_code == 404
+    assert response.json() == {
+        "error": {
+            "code": "not_found",
+            "message": f"Namespace with id={new_namespace.id!r} not found",
+            "details": {
+                "entity_type": "Namespace",
+                "field": "id",
+                "value": new_namespace.id,
+            },
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "namespace_with_users",
+    [
+        [
+            ("user1", NamespaceUserRole.DEVELOPER),
+            ("user2", NamespaceUserRole.DEVELOPER),
+            ("user3", NamespaceUserRole.MAINTAINER),
+        ]
+    ],
+    indirect=["namespace_with_users"],
+)
+async def test_update_namespace_permissions_with_duplicates_usernames(
+    test_client: AsyncClient,
+    access_token: str,
+    namespace_with_users: None,
+    namespace: Namespace,
+):
+    changes = {
+        "permissions": [
+            {"username": "user1", "role": "DEVELOPER"},
+            {"username": "user1", "role": "MAINTAINER"},
+            {"username": "user2", "role": "OWNER"},
+        ]
+    }
+    response = await test_client.patch(
+        f"/v1/namespace/{namespace.id}/permissions",
+        headers={"Authorization": f"Bearer {access_token}"},
+        json=changes,
+    )
+    assert response.status_code == 400
+    assert response.json() == {
+        "error": {
+            "code": "bad_request",
+            "message": "Duplicate username detected: user1. Each username must appear only once.",
+            "details": None,
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "namespace_with_users",
+    [
+        [
+            ("user1", NamespaceUserRole.DEVELOPER),
+            ("user2", NamespaceUserRole.DEVELOPER),
+            ("user3", NamespaceUserRole.MAINTAINER),
+        ]
+    ],
+    indirect=["namespace_with_users"],
+)
+async def test_update_namespace_permissions_duplicates_owner(
+    test_client: AsyncClient,
+    access_token: str,
+    namespace_with_users: None,
+    namespace: Namespace,
+):
+    changes = {
+        "permissions": [
+            {"username": "user1", "role": "DEVELOPER"},
+            {"username": "user2", "role": "OWNER"},
+            {"username": "user3", "role": "OWNER"},
+        ]
+    }
+    response = await test_client.patch(
+        f"/v1/namespace/{namespace.id}/permissions",
+        headers={"Authorization": f"Bearer {access_token}"},
+        json=changes,
+    )
+    assert response.status_code == 400
+    assert response.json() == {
+        "error": {
+            "code": "bad_request",
+            "message": "Multiple owner role assignments detected. Only one owner can be assigned.",
+            "details": None,
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "namespace_with_users",
+    [
+        [
+            ("user1", NamespaceUserRole.DEVELOPER),
+            ("user2", NamespaceUserRole.DEVELOPER),
+            ("user3", NamespaceUserRole.MAINTAINER),
+        ]
+    ],
+    indirect=["namespace_with_users"],
+)
+async def test_update_namespace_permissions_lose_owner(
+    test_client: AsyncClient,
+    access_token: str,
+    user: User,
+    namespace_with_users: None,
+    namespace: Namespace,
+):
+    changes = {
+        "permissions": [
+            {"username": user.username, "role": "DEVELOPER"},
+        ]
+    }
+    response = await test_client.patch(
+        f"/v1/namespace/{namespace.id}/permissions",
+        headers={"Authorization": f"Bearer {access_token}"},
+        json=changes,
+    )
+    assert response.status_code == 400
+    assert response.json() == {
+        "error": {
+            "code": "bad_request",
+            "message": "Operation forbidden: The current owner cannot change their "
+            "rights without reassigning them to another user.",
+            "details": None,
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "namespace_with_users",
+    [
+        [
+            ("user1", NamespaceUserRole.DEVELOPER),
+            ("user2", NamespaceUserRole.MAINTAINER),
+            ("user3", NamespaceUserRole.DEVELOPER),
+        ]
+    ],
+    indirect=["namespace_with_users"],
+)
+async def test_update_namespace_permissions_remove_role(
+    test_client: AsyncClient,
+    access_token: str,
+    namespace_with_users: None,
+    namespace: Namespace,
+):
+    changes = {
+        "permissions": [
+            {"username": "user3", "role": None},
+        ]
+    }
+    response = await test_client.patch(
+        f"/v1/namespace/{namespace.id}/permissions",
+        headers={"Authorization": f"Bearer {access_token}"},
+        json=changes,
+    )
+    assert response.status_code == 200
+    permissions = response.json()["permissions"]
+
+    assert not any(perm["username"] == "user3" for perm in permissions)
+
+
+@pytest.mark.parametrize(
+    "namespace_with_users",
+    [
+        [
+            ("user1", NamespaceUserRole.DEVELOPER),
+            ("user2", NamespaceUserRole.MAINTAINER),
+        ]
+    ],
+    indirect=["namespace_with_users"],
+)
+async def test_update_namespace_permissions_add_or_update_roles(
+    test_client: AsyncClient,
+    access_token: str,
+    namespace_with_users: None,
+    namespace: Namespace,
+):
+    changes = {
+        "permissions": [
+            {"username": "user1", "role": "MAINTAINER"},
+            {"username": "user2", "role": "DEVELOPER"},
+        ]
+    }
+
+    response = await test_client.patch(
+        f"/v1/namespace/{namespace.id}/permissions",
+        headers={"Authorization": f"Bearer {access_token}"},
+        json=changes,
+    )
+
+    assert response.status_code == 200
+    updated_permissions = response.json()["permissions"]
+    expected_roles = {change["username"]: change["role"] for change in changes["permissions"]}
+
+    for permission in updated_permissions:
+        assert (
+            permission["role"] == expected_roles[permission["username"]]
+        ), f"{permission['username']} role should be {expected_roles[permission['username']]}"
+
+
+@pytest.mark.parametrize(
+    "namespace_with_users",
+    [
+        [("existing_owner", NamespaceUserRole.OWNER), ("user_to_become_owner", NamespaceUserRole.DEVELOPER)],
+    ],
+    indirect=["namespace_with_users"],
+)
+async def test_update_namespace_permissions_change_owner(
+    test_client: AsyncClient,
+    access_token: str,
+    namespace_with_users: None,
+    namespace: Namespace,
+):
+    changes = {
+        "permissions": [
+            {"username": "user_to_become_owner", "role": "OWNER"},
+        ]
+    }
+
+    response = await test_client.patch(
+        f"/v1/namespace/{namespace.id}/permissions",
+        headers={"Authorization": f"Bearer {access_token}"},
+        json=changes,
+    )
+
+    assert response.status_code == 200
 
 
 @pytest.mark.parametrize(

--- a/tests/test_backend/test_permissions/test_update_permissions.py
+++ b/tests/test_backend/test_permissions/test_update_permissions.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from horizon.backend.db.models import Namespace, NamespaceUserRole, User
+from horizon.backend.db.models import Namespace, NamespaceUserRoleInt, User
 
 if TYPE_CHECKING:
     from httpx import AsyncClient
@@ -21,7 +21,7 @@ async def test_update_namespace_permissions_unauthorized_user(
 ):
     changes = {
         "permissions": [
-            {"username": secrets.token_hex(6), "role": NamespaceUserRole.DEVELOPER.name},
+            {"username": secrets.token_hex(6), "role": NamespaceUserRoleInt.DEVELOPER.name},
         ]
     }
     response = await test_client.patch(
@@ -45,7 +45,7 @@ async def test_update_namespace_permissions_namespace_missing(
 ):
     changes = {
         "permissions": [
-            {"username": secrets.token_hex(6), "role": NamespaceUserRole.DEVELOPER.name},
+            {"username": secrets.token_hex(6), "role": NamespaceUserRoleInt.DEVELOPER.name},
         ]
     }
     response = await test_client.patch(
@@ -71,9 +71,9 @@ async def test_update_namespace_permissions_namespace_missing(
     "namespace_with_users",
     [
         [
-            ("user1", NamespaceUserRole.DEVELOPER),
-            ("user2", NamespaceUserRole.DEVELOPER),
-            ("user3", NamespaceUserRole.MAINTAINER),
+            ("user1", NamespaceUserRoleInt.DEVELOPER),
+            ("user2", NamespaceUserRoleInt.DEVELOPER),
+            ("user3", NamespaceUserRoleInt.MAINTAINER),
         ]
     ],
     indirect=["namespace_with_users"],
@@ -110,9 +110,9 @@ async def test_update_namespace_permissions_with_duplicates_usernames(
     "namespace_with_users",
     [
         [
-            ("user1", NamespaceUserRole.DEVELOPER),
-            ("user2", NamespaceUserRole.DEVELOPER),
-            ("user3", NamespaceUserRole.MAINTAINER),
+            ("user1", NamespaceUserRoleInt.DEVELOPER),
+            ("user2", NamespaceUserRoleInt.DEVELOPER),
+            ("user3", NamespaceUserRoleInt.MAINTAINER),
         ]
     ],
     indirect=["namespace_with_users"],
@@ -149,9 +149,9 @@ async def test_update_namespace_permissions_duplicates_owner(
     "namespace_with_users",
     [
         [
-            ("user1", NamespaceUserRole.DEVELOPER),
-            ("user2", NamespaceUserRole.DEVELOPER),
-            ("user3", NamespaceUserRole.MAINTAINER),
+            ("user1", NamespaceUserRoleInt.DEVELOPER),
+            ("user2", NamespaceUserRoleInt.DEVELOPER),
+            ("user3", NamespaceUserRoleInt.MAINTAINER),
         ]
     ],
     indirect=["namespace_with_users"],
@@ -188,9 +188,9 @@ async def test_update_namespace_permissions_lose_owner(
     "namespace_with_users",
     [
         [
-            ("user1", NamespaceUserRole.DEVELOPER),
-            ("user2", NamespaceUserRole.MAINTAINER),
-            ("user3", NamespaceUserRole.DEVELOPER),
+            ("user1", NamespaceUserRoleInt.DEVELOPER),
+            ("user2", NamespaceUserRoleInt.MAINTAINER),
+            ("user3", NamespaceUserRoleInt.DEVELOPER),
         ]
     ],
     indirect=["namespace_with_users"],
@@ -221,8 +221,8 @@ async def test_update_namespace_permissions_remove_role(
     "namespace_with_users",
     [
         [
-            ("user1", NamespaceUserRole.DEVELOPER),
-            ("user2", NamespaceUserRole.MAINTAINER),
+            ("user1", NamespaceUserRoleInt.DEVELOPER),
+            ("user2", NamespaceUserRoleInt.MAINTAINER),
         ]
     ],
     indirect=["namespace_with_users"],
@@ -259,7 +259,7 @@ async def test_update_namespace_permissions_add_or_update_roles(
 @pytest.mark.parametrize(
     "namespace_with_users",
     [
-        [("existing_owner", NamespaceUserRole.OWNER), ("user_to_become_owner", NamespaceUserRole.DEVELOPER)],
+        [("existing_owner", NamespaceUserRoleInt.OWNER), ("user_to_become_owner", NamespaceUserRoleInt.DEVELOPER)],
     ],
     indirect=["namespace_with_users"],
 )
@@ -288,7 +288,7 @@ async def test_update_namespace_permissions_change_owner(
     "user_with_role, expected_status, expected_response",
     [
         (
-            NamespaceUserRole.MAINTAINER,
+            NamespaceUserRoleInt.MAINTAINER,
             403,
             {
                 "error": {
@@ -302,7 +302,7 @@ async def test_update_namespace_permissions_change_owner(
             },
         ),
         (
-            NamespaceUserRole.DEVELOPER,
+            NamespaceUserRoleInt.DEVELOPER,
             403,
             {
                 "error": {
@@ -316,7 +316,7 @@ async def test_update_namespace_permissions_change_owner(
             },
         ),
         (
-            NamespaceUserRole.GUEST,
+            NamespaceUserRoleInt.GUEST,
             403,
             {
                 "error": {

--- a/tests/test_client_sync/test_permissions/test_client_sync_get_permissions.py
+++ b/tests/test_client_sync/test_permissions/test_client_sync_get_permissions.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2023 MTS (Mobile Telesystems)
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import re
+
+import pytest
+import requests
+
+from horizon.backend.db.models import Namespace, NamespaceUserRole, User
+from horizon.client.sync import HorizonClientSync
+from horizon.commons.exceptions.entity import EntityNotFoundError
+from horizon.commons.schemas.v1 import PermissionResponseItemV1, PermissionsResponseV1
+
+pytestmark = [pytest.mark.client_sync, pytest.mark.client]
+
+
+def test_sync_client_get_namespace_permissions(namespace: Namespace, user: User, sync_client: HorizonClientSync):
+    response = sync_client.get_namespace_permissions(namespace.id)
+    assert response == PermissionsResponseV1(
+        permissions=[PermissionResponseItemV1(username=user.username, role=NamespaceUserRole.OWNER.name)]
+    )
+
+
+def test_sync_client_get_namespace_permissions_missing(new_namespace: Namespace, sync_client: HorizonClientSync):
+    with pytest.raises(
+        EntityNotFoundError,
+        match=re.escape(f"Namespace with id={new_namespace.id!r} not found"),
+    ) as e:
+        sync_client.get_namespace_permissions(new_namespace.id)
+
+    assert e.value.details == {
+        "entity_type": "Namespace",
+        "field": "id",
+        "value": new_namespace.id,
+    }
+
+    # original HTTP exception is attached as reason
+    assert isinstance(e.value.__cause__, requests.exceptions.HTTPError)
+    assert e.value.__cause__.response.status_code == 404

--- a/tests/test_client_sync/test_permissions/test_client_sync_get_permissions.py
+++ b/tests/test_client_sync/test_permissions/test_client_sync_get_permissions.py
@@ -8,7 +8,7 @@ import re
 import pytest
 import requests
 
-from horizon.backend.db.models import Namespace, NamespaceUserRole, User
+from horizon.backend.db.models import Namespace, NamespaceUserRoleInt, User
 from horizon.client.sync import HorizonClientSync
 from horizon.commons.exceptions.entity import EntityNotFoundError
 from horizon.commons.schemas.v1 import PermissionResponseItemV1, PermissionsResponseV1
@@ -19,7 +19,7 @@ pytestmark = [pytest.mark.client_sync, pytest.mark.client]
 def test_sync_client_get_namespace_permissions(namespace: Namespace, user: User, sync_client: HorizonClientSync):
     response = sync_client.get_namespace_permissions(namespace.id)
     assert response == PermissionsResponseV1(
-        permissions=[PermissionResponseItemV1(username=user.username, role=NamespaceUserRole.OWNER.name)]
+        permissions=[PermissionResponseItemV1(username=user.username, role=NamespaceUserRoleInt.OWNER.name)]
     )
 
 

--- a/tests/test_client_sync/test_permissions/test_client_sync_update_permsisions.py
+++ b/tests/test_client_sync/test_permissions/test_client_sync_update_permsisions.py
@@ -64,38 +64,3 @@ def test_sync_client_update_namespace_permissions_namespace_missing(
 
     assert isinstance(exc_info.value.__cause__, requests.exceptions.HTTPError)
     assert exc_info.value.__cause__.response.status_code == 404
-
-
-@pytest.mark.parametrize(
-    "namespace_with_users",
-    [
-        [
-            ("owner_user", NamespaceUserRole.OWNER),
-            ("user1", NamespaceUserRole.DEVELOPER),
-            ("user2", NamespaceUserRole.DEVELOPER),
-        ],
-    ],
-    indirect=["namespace_with_users"],
-)
-@pytest.mark.parametrize(
-    "invalid_changes",
-    [
-        PermissionsUpdateRequestV1(
-            permissions=[
-                PermissionUpdateRequestItemV1(username="user1", role="OWNER"),
-                PermissionUpdateRequestItemV1(username="user2", role="OWNER"),
-            ]
-        ),
-    ],
-)
-def test_sync_client_update_namespace_permissions_invalid_request(
-    namespace: Namespace,
-    invalid_changes: PermissionsUpdateRequestV1,
-    sync_client: HorizonClientSync,
-    namespace_with_users: None,
-):
-    with pytest.raises(BadRequestError) as exc_info:
-        sync_client.update_namespace_permissions(namespace.id, invalid_changes)
-
-    assert isinstance(exc_info.value.__cause__, requests.exceptions.HTTPError)
-    assert exc_info.value.__cause__.response.status_code == 400

--- a/tests/test_client_sync/test_permissions/test_client_sync_update_permsisions.py
+++ b/tests/test_client_sync/test_permissions/test_client_sync_update_permsisions.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: 2023 MTS (Mobile Telesystems)
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import re
+
+import pytest
+import requests
+
+from horizon.backend.db.models import Namespace, NamespaceUserRole, User
+from horizon.client.sync import HorizonClientSync
+from horizon.commons.exceptions import EntityNotFoundError, PermissionDeniedError
+from horizon.commons.schemas.v1 import (
+    PermissionsResponseV1,
+    PermissionsUpdateRequestV1,
+    PermissionUpdateRequestItemV1,
+)
+
+pytestmark = [pytest.mark.client_sync, pytest.mark.client]
+
+
+@pytest.mark.parametrize(
+    "namespace_with_users",
+    [
+        [("new_user", NamespaceUserRole.MAINTAINER)],
+    ],
+    indirect=["namespace_with_users"],
+)
+def test_sync_client_update_namespace_permissions(
+    namespace: Namespace, user: User, sync_client: HorizonClientSync, namespace_with_users: None
+):
+    changes = PermissionsUpdateRequestV1(
+        permissions=[
+            PermissionUpdateRequestItemV1(username=user.username, role=NamespaceUserRole.DEVELOPER.name),
+            PermissionUpdateRequestItemV1(username="new_user", role=NamespaceUserRole.OWNER.name),
+        ]
+    )
+    response = sync_client.update_namespace_permissions(namespace.id, changes)
+
+    assert isinstance(response, PermissionsResponseV1)
+    assert any(
+        perm.username == user.username and perm.role == NamespaceUserRole.DEVELOPER.name
+        for perm in response.permissions
+    )
+    assert any(
+        perm.username == "new_user" and perm.role == NamespaceUserRole.OWNER.name for perm in response.permissions
+    )
+
+
+def test_sync_client_update_namespace_permissions_namespace_missing(
+    new_namespace: Namespace, sync_client: HorizonClientSync
+):
+    changes = PermissionsUpdateRequestV1(
+        permissions=[
+            PermissionUpdateRequestItemV1(username="someuser", role=NamespaceUserRole.DEVELOPER.name),
+        ]
+    )
+    with pytest.raises(
+        EntityNotFoundError,
+        match=re.escape(f"Namespace with id={new_namespace.id!r} not found"),
+    ) as exc_info:
+        sync_client.update_namespace_permissions(new_namespace.id, changes)
+
+    assert isinstance(exc_info.value.__cause__, requests.exceptions.HTTPError)
+    assert exc_info.value.__cause__.response.status_code == 404
+
+
+@pytest.mark.parametrize(
+    "namespace_with_users",
+    [
+        [
+            ("owner_user", NamespaceUserRole.OWNER),
+            ("user1", NamespaceUserRole.DEVELOPER),
+            ("user2", NamespaceUserRole.DEVELOPER),
+        ],
+    ],
+    indirect=["namespace_with_users"],
+)
+@pytest.mark.parametrize(
+    "invalid_changes",
+    [
+        PermissionsUpdateRequestV1(
+            permissions=[
+                PermissionUpdateRequestItemV1(username="user1", role="OWNER"),
+                PermissionUpdateRequestItemV1(username="user2", role="OWNER"),
+            ]
+        ),
+    ],
+)
+def test_sync_client_update_namespace_permissions_invalid(
+    namespace: Namespace,
+    invalid_changes: PermissionsUpdateRequestV1,
+    sync_client: HorizonClientSync,
+    namespace_with_users: None,
+):
+    with pytest.raises(requests.exceptions.HTTPError) as exc_info:
+        sync_client.update_namespace_permissions(namespace.id, invalid_changes)
+
+    assert exc_info.value.response.status_code == 400

--- a/tests/test_client_sync/test_permissions/test_client_sync_update_permsisions.py
+++ b/tests/test_client_sync/test_permissions/test_client_sync_update_permsisions.py
@@ -8,7 +8,7 @@ import re
 import pytest
 import requests
 
-from horizon.backend.db.models import Namespace, NamespaceUserRole, User
+from horizon.backend.db.models import Namespace, NamespaceUserRoleInt, User
 from horizon.client.sync import HorizonClientSync
 from horizon.commons.exceptions import BadRequestError, EntityNotFoundError
 from horizon.commons.schemas.v1 import (
@@ -23,7 +23,7 @@ pytestmark = [pytest.mark.client_sync, pytest.mark.client]
 @pytest.mark.parametrize(
     "namespace_with_users",
     [
-        [("new_user", NamespaceUserRole.MAINTAINER)],
+        [("new_user", NamespaceUserRoleInt.MAINTAINER)],
     ],
     indirect=["namespace_with_users"],
 )
@@ -32,19 +32,19 @@ def test_sync_client_update_namespace_permissions(
 ):
     changes = PermissionsUpdateRequestV1(
         permissions=[
-            PermissionUpdateRequestItemV1(username=user.username, role=NamespaceUserRole.DEVELOPER.name),
-            PermissionUpdateRequestItemV1(username="new_user", role=NamespaceUserRole.OWNER.name),
+            PermissionUpdateRequestItemV1(username=user.username, role=NamespaceUserRoleInt.DEVELOPER.name),
+            PermissionUpdateRequestItemV1(username="new_user", role=NamespaceUserRoleInt.OWNER.name),
         ]
     )
     response = sync_client.update_namespace_permissions(namespace.id, changes)
 
     assert isinstance(response, PermissionsResponseV1)
     assert any(
-        perm.username == user.username and perm.role == NamespaceUserRole.DEVELOPER.name
+        perm.username == user.username and perm.role == NamespaceUserRoleInt.DEVELOPER.name
         for perm in response.permissions
     )
     assert any(
-        perm.username == "new_user" and perm.role == NamespaceUserRole.OWNER.name for perm in response.permissions
+        perm.username == "new_user" and perm.role == NamespaceUserRoleInt.OWNER.name for perm in response.permissions
     )
 
 
@@ -53,7 +53,7 @@ def test_sync_client_update_namespace_permissions_namespace_missing(
 ):
     changes = PermissionsUpdateRequestV1(
         permissions=[
-            PermissionUpdateRequestItemV1(username="someuser", role=NamespaceUserRole.DEVELOPER.name),
+            PermissionUpdateRequestItemV1(username="someuser", role=NamespaceUserRoleInt.DEVELOPER.name),
         ]
     )
     with pytest.raises(

--- a/tests/test_client_sync/test_permissions/test_client_sync_update_permsisions.py
+++ b/tests/test_client_sync/test_permissions/test_client_sync_update_permsisions.py
@@ -10,8 +10,9 @@ import requests
 
 from horizon.backend.db.models import Namespace, NamespaceUserRoleInt, User
 from horizon.client.sync import HorizonClientSync
-from horizon.commons.exceptions import BadRequestError, EntityNotFoundError
+from horizon.commons.exceptions import EntityNotFoundError
 from horizon.commons.schemas.v1 import (
+    NamespaceUserRole,
     PermissionsResponseV1,
     PermissionsUpdateRequestV1,
     PermissionUpdateRequestItemV1,
@@ -32,20 +33,17 @@ def test_sync_client_update_namespace_permissions(
 ):
     changes = PermissionsUpdateRequestV1(
         permissions=[
-            PermissionUpdateRequestItemV1(username=user.username, role=NamespaceUserRoleInt.DEVELOPER.name),
-            PermissionUpdateRequestItemV1(username="new_user", role=NamespaceUserRoleInt.OWNER.name),
+            PermissionUpdateRequestItemV1(username=user.username, role=NamespaceUserRole.DEVELOPER),
+            PermissionUpdateRequestItemV1(username="new_user", role=NamespaceUserRole.OWNER),
         ]
     )
     response = sync_client.update_namespace_permissions(namespace.id, changes)
 
     assert isinstance(response, PermissionsResponseV1)
     assert any(
-        perm.username == user.username and perm.role == NamespaceUserRoleInt.DEVELOPER.name
-        for perm in response.permissions
+        perm.username == user.username and perm.role == NamespaceUserRole.DEVELOPER for perm in response.permissions
     )
-    assert any(
-        perm.username == "new_user" and perm.role == NamespaceUserRoleInt.OWNER.name for perm in response.permissions
-    )
+    assert any(perm.username == "new_user" and perm.role == NamespaceUserRole.OWNER for perm in response.permissions)
 
 
 def test_sync_client_update_namespace_permissions_namespace_missing(
@@ -53,7 +51,7 @@ def test_sync_client_update_namespace_permissions_namespace_missing(
 ):
     changes = PermissionsUpdateRequestV1(
         permissions=[
-            PermissionUpdateRequestItemV1(username="someuser", role=NamespaceUserRoleInt.DEVELOPER.name),
+            PermissionUpdateRequestItemV1(username="someuser", role=NamespaceUserRole.DEVELOPER),
         ]
     )
     with pytest.raises(

--- a/tests/test_client_sync/test_permissions/test_client_sync_update_permsisions.py
+++ b/tests/test_client_sync/test_permissions/test_client_sync_update_permsisions.py
@@ -10,7 +10,7 @@ import requests
 
 from horizon.backend.db.models import Namespace, NamespaceUserRole, User
 from horizon.client.sync import HorizonClientSync
-from horizon.commons.exceptions import EntityNotFoundError, PermissionDeniedError
+from horizon.commons.exceptions import BadRequestError, EntityNotFoundError
 from horizon.commons.schemas.v1 import (
     PermissionsResponseV1,
     PermissionsUpdateRequestV1,
@@ -88,13 +88,14 @@ def test_sync_client_update_namespace_permissions_namespace_missing(
         ),
     ],
 )
-def test_sync_client_update_namespace_permissions_invalid(
+def test_sync_client_update_namespace_permissions_invalid_request(
     namespace: Namespace,
     invalid_changes: PermissionsUpdateRequestV1,
     sync_client: HorizonClientSync,
     namespace_with_users: None,
 ):
-    with pytest.raises(requests.exceptions.HTTPError) as exc_info:
+    with pytest.raises(BadRequestError) as exc_info:
         sync_client.update_namespace_permissions(namespace.id, invalid_changes)
 
-    assert exc_info.value.response.status_code == 400
+    assert isinstance(exc_info.value.__cause__, requests.exceptions.HTTPError)
+    assert exc_info.value.__cause__.response.status_code == 400


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/horizon/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

- add new API endpoint ``PATCH /namespace/:id/permissions`` for updating the permissions of users within a namespace.
- add new API endpoint ``GET /namespace/:id/permissions`` for fetching the permissions of users within a specific namespace.
- extend the Python client library with methods `get_namespace_permissions` and `update_namespace_permissions` to interact with the new API endpoints.
- update following tests and documentation

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [x] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/horizon/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
