### PR TITLE
[DOP-13012] Move permissions check to endpoints

### DIFF
--- a/horizon/backend/api/v1/router/permission.py
+++ b/horizon/backend/api/v1/router/permission.py
@@ -4,12 +4,12 @@
 from fastapi import APIRouter, Depends
 from typing_extensions import Annotated
 
-from horizon.backend.db.models import NamespaceUserRoleInt, User
+from horizon.backend.db.models import User
 from horizon.backend.services import UnitOfWork, current_user
+from horizon.commons.dto import Role
 from horizon.commons.errors import get_error_responses
-from horizon.commons.exceptions import BadRequestError
+from horizon.commons.exceptions import BadRequestError, PermissionDeniedError
 from horizon.commons.schemas.v1 import (
-    NamespaceUserRole,
     PermissionResponseItemV1,
     PermissionsResponseV1,
     PermissionsUpdateRequestV1,
@@ -24,39 +24,44 @@ async def get_namespace_permissions(
     unit_of_work: Annotated[UnitOfWork, Depends()],
     user: Annotated[User, Depends(current_user)],
 ) -> PermissionsResponseV1:
-    async with unit_of_work:
-        await unit_of_work.namespace.check_user_permission(
-            user_id=user.id,
-            namespace_id=namespace_id,
-            required_role=NamespaceUserRoleInt.OWNER,
-        )
-        permissions_dict = await unit_of_work.namespace.get_namespace_users_permissions(namespace_id)
+    namespace = await unit_of_work.namespace.get(namespace_id)
 
-        permissions_response = [
-            PermissionResponseItemV1(username=user.username, role=role.name) for user, role in permissions_dict.items()
-        ]
+    role = await unit_of_work.namespace.get_user_role(
+        user_id=user.id,
+        namespace_id=namespace.id,
+    )
+    if role != Role.OWNER:
+        raise PermissionDeniedError(required_role="OWNER", actual_role=role.name if role else "GUEST")
+
+    roles_dict = await unit_of_work.namespace.get_all_roles(namespace.id)
+    permissions_response = [
+        PermissionResponseItemV1(username=user.username, role=role) for user, role in roles_dict.items()
+    ]
 
     return PermissionsResponseV1(permissions=permissions_response)
 
 
 @router.patch(
     "/{namespace_id}/permissions",
-    summary="Update namespace permissions",
+    summary="Set namespace permissions",
     dependencies=[Depends(current_user)],
 )
-async def update_namespace_permissions(
+async def set_namespace_permissions(  # noqa: WPS231, WPS217
     namespace_id: int,
     changes: PermissionsUpdateRequestV1,
     unit_of_work: Annotated[UnitOfWork, Depends()],
     user: Annotated[User, Depends(current_user)],
 ) -> PermissionsResponseV1:
-    async with unit_of_work:
-        await unit_of_work.namespace.check_user_permission(
-            user_id=user.id,
-            namespace_id=namespace_id,
-            required_role=NamespaceUserRoleInt.OWNER,
-        )
+    namespace = await unit_of_work.namespace.get(namespace_id)
 
+    role = await unit_of_work.namespace.get_user_role(
+        user_id=user.id,
+        namespace_id=namespace.id,
+    )
+    if role != Role.OWNER:
+        raise PermissionDeniedError(required_role="OWNER", actual_role=role.name if role else "GUEST")
+
+    async with unit_of_work:
         updated_permissions_response = []
         owner_change_detected = False
 
@@ -64,25 +69,23 @@ async def update_namespace_permissions(
             update_user = await unit_of_work.user.get_by_username(perm.username)
 
             # Ensure the current owner isn't changing their role without assigning a new owner
-            if update_user.id == user.id and perm.role != NamespaceUserRole.OWNER:
-                if not any(
-                    p.role == NamespaceUserRole.OWNER for p in changes.permissions if p.username != user.username
-                ):
+            if update_user.id == user.id and perm.role != Role.OWNER:
+                if not any(p.role == Role.OWNER for p in changes.permissions if p.username != user.username):
                     raise BadRequestError(
-                        "Operation forbidden: The current owner cannot change their rights without reassigning them to another user.",
+                        "Operation forbidden: The current owner cannot change own role without reassigning it to another user.",
                     )
 
             if perm.role:
-                if perm.role == NamespaceUserRole.OWNER and not owner_change_detected:
-                    await unit_of_work.namespace.set_new_owner(namespace_id, update_user.id)
+                if perm.role == Role.OWNER and not owner_change_detected:
+                    await unit_of_work.namespace.update(namespace.id, {"owner_id": update_user.id}, update_user)
+                    await unit_of_work.namespace.delete_role(namespace.id, update_user.id)
                     owner_change_detected = True
                 else:
-                    role_enum = NamespaceUserRoleInt[perm.role.upper()]
-                    await unit_of_work.namespace.update_permission(namespace_id, update_user.id, role_enum)
+                    await unit_of_work.namespace.set_role(namespace.id, update_user.id, perm.role)
                 updated_permissions_response.append(
                     PermissionResponseItemV1(username=perm.username, role=perm.role),
                 )
             else:
-                await unit_of_work.namespace.delete_permission(namespace_id, update_user.id)
+                await unit_of_work.namespace.delete_role(namespace.id, update_user.id)
 
         return PermissionsResponseV1(permissions=updated_permissions_response)

--- a/horizon/backend/db/migrations/versions/2024-03-01_4c60578f3f1d_.py
+++ b/horizon/backend/db/migrations/versions/2024-03-01_4c60578f3f1d_.py
@@ -21,7 +21,7 @@ def upgrade() -> None:
         "namespace_user",
         sa.Column("namespace_id", sa.BigInteger(), nullable=False),
         sa.Column("user_id", sa.BigInteger(), nullable=False),
-        sa.Column("role", sa.String(length=50), nullable=False),
+        sa.Column("role", sa.String(length=255), nullable=False),
         sa.ForeignKeyConstraint(
             ["namespace_id"],
             ["namespace.id"],

--- a/horizon/backend/db/models/__init__.py
+++ b/horizon/backend/db/models/__init__.py
@@ -4,7 +4,7 @@ from horizon.backend.db.models.base import Base
 from horizon.backend.db.models.credentials_cache import CredentialsCache
 from horizon.backend.db.models.hwm import HWM
 from horizon.backend.db.models.hwm_history import HWMHistory
-from horizon.backend.db.models.namespace import Namespace, NamespaceUserRoleInt
+from horizon.backend.db.models.namespace import Namespace
 from horizon.backend.db.models.namespace_history import NamespaceHistory
 from horizon.backend.db.models.namespace_user import NamespaceUser
 from horizon.backend.db.models.user import User

--- a/horizon/backend/db/models/namespace.py
+++ b/horizon/backend/db/models/namespace.py
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: 2023-2024 MTS (Mobile Telesystems)
 # SPDX-License-Identifier: Apache-2.0
-from enum import IntEnum
 
 from sqlalchemy import BigInteger, ForeignKey, String, Text
 from sqlalchemy.ext.associationproxy import AssociationProxy, association_proxy
@@ -8,13 +7,6 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from horizon.backend.db.mixins.changed_by import ChangedByMixin
 from horizon.backend.db.models.base import Base
-
-
-class NamespaceUserRoleInt(IntEnum):
-    GUEST = 0
-    DEVELOPER = 1
-    MAINTAINER = 2
-    OWNER = 3
 
 
 class Namespace(Base, ChangedByMixin):

--- a/horizon/backend/db/models/namespace_user.py
+++ b/horizon/backend/db/models/namespace_user.py
@@ -1,9 +1,11 @@
 # SPDX-FileCopyrightText: 2023-2024 MTS (Mobile Telesystems)
 # SPDX-License-Identifier: Apache-2.0
-from sqlalchemy import BigInteger, ForeignKey, String
+from sqlalchemy import BigInteger, ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy_utils import ChoiceType
 
 from horizon.backend.db.models.base import Base
+from horizon.commons.dto.role import Role
 
 
 class NamespaceUser(Base):
@@ -19,7 +21,7 @@ class NamespaceUser(Base):
         ForeignKey("user.id", ondelete="CASCADE"),
         primary_key=True,
     )
-    role: Mapped[str] = mapped_column(
-        String(50),  # noqa: WPS432
+    role: Mapped[Role] = mapped_column(
+        ChoiceType(Role),
         nullable=False,
     )

--- a/horizon/commons/dto/__init__.py
+++ b/horizon/commons/dto/__init__.py
@@ -2,9 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from horizon.commons.dto.pagination import Pagination
+from horizon.commons.dto.role import Role
 from horizon.commons.dto.unset import Unset
 
 __all__ = [
     "Pagination",
+    "Role",
     "Unset",
 ]

--- a/horizon/commons/dto/role.py
+++ b/horizon/commons/dto/role.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2023-2024 MTS (Mobile Telesystems)
+# SPDX-License-Identifier: Apache-2.0
+from enum import Enum
+
+
+class Role(str, Enum):  # noqa: WPS60
+    DEVELOPER = "DEVELOPER"
+    MAINTAINER = "MAINTAINER"
+    OWNER = "OWNER"

--- a/horizon/commons/schemas/v1/__init__.py
+++ b/horizon/commons/schemas/v1/__init__.py
@@ -16,7 +16,6 @@ from horizon.commons.schemas.v1.namespace import (
     NamespacePaginateQueryV1,
     NamespaceResponseV1,
     NamespaceUpdateRequestV1,
-    NamespaceUserRole,
 )
 from horizon.commons.schemas.v1.namespace_history import (
     NamespaceHistoryPaginateQueryV1,

--- a/horizon/commons/schemas/v1/namespace.py
+++ b/horizon/commons/schemas/v1/namespace.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2023-2024 MTS (Mobile Telesystems)
 # SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
-from enum import Enum
 from typing import Optional, Union
 
 from pydantic import BaseModel, Field, root_validator
@@ -10,12 +9,6 @@ from horizon.commons.dto import Unset
 from horizon.commons.schemas.v1.pagination import PaginateQueryV1
 
 MAX_NAME_LENGTH = 256
-
-
-class NamespaceUserRole(str, Enum):  # noqa: WPS60
-    DEVELOPER = "DEVELOPER"
-    MAINTAINER = "MAINTAINER"
-    OWNER = "OWNER"
 
 
 class NamespaceResponseV1(BaseModel):

--- a/horizon/commons/schemas/v1/permission.py
+++ b/horizon/commons/schemas/v1/permission.py
@@ -4,14 +4,14 @@ from typing import List, Optional, Set
 
 from pydantic import BaseModel, Field, validator
 
-from horizon.commons.schemas.v1 import NamespaceUserRole
+from horizon.commons.dto import Role
 
 
 class PermissionResponseItemV1(BaseModel):
     """Represents a single permission entry in a response, linking a user with their role within a namespace."""
 
     username: str
-    role: NamespaceUserRole
+    role: Role
 
 
 class PermissionsResponseV1(BaseModel):
@@ -24,7 +24,7 @@ class PermissionUpdateRequestItemV1(BaseModel):
     """Represents a single permission entry in a request, specifying a desired role for a user within a namespace."""
 
     username: str
-    role: Optional[NamespaceUserRole] = Field(
+    role: Optional[Role] = Field(
         default=None,
         description="The role to be assigned to the user within the namespace."
         " A value of `None` indicates that the permission should be removed.",
@@ -50,7 +50,7 @@ class PermissionsUpdateRequestV1(BaseModel):
                 raise ValueError(f"Duplicate username detected: {username}. Each username must appear only once.")
             seen.add(username)
 
-            if role == NamespaceUserRole.OWNER:
+            if role == Role.OWNER:
                 owner_count += 1
 
         if owner_count > 1:

--- a/tests/test_backend/test_hwm/test_delete_hwm.py
+++ b/tests/test_backend/test_hwm/test_delete_hwm.py
@@ -8,8 +8,8 @@ from typing import TYPE_CHECKING
 import pytest
 from sqlalchemy import select
 
-from horizon.backend.db.models import HWM, NamespaceUserRoleInt, User
-from horizon.backend.db.models.hwm_history import HWMHistory
+from horizon.backend.db.models import HWM, HWMHistory, User
+from horizon.commons.dto import Role
 
 if TYPE_CHECKING:
     from httpx import AsyncClient
@@ -61,10 +61,10 @@ async def test_delete_hwm_missing(
 @pytest.mark.parametrize(
     "user_with_role",
     [
-        NamespaceUserRoleInt.OWNER,
-        NamespaceUserRoleInt.MAINTAINER,
+        Role.OWNER,
+        Role.MAINTAINER,
     ],
-    indirect=["user_with_role"],
+    indirect=True,
 )
 async def test_delete_hwm(
     test_client: AsyncClient,
@@ -109,31 +109,31 @@ async def test_delete_hwm(
     "user_with_role, expected_status, expected_response",
     [
         (
-            NamespaceUserRoleInt.DEVELOPER,
+            Role.DEVELOPER,
             403,
             {
                 "error": {
                     "code": "permission_denied",
-                    "message": f"Permission denied. User has role DEVELOPER but action requires at least MAINTAINER.",
+                    "message": "Permission denied. User has role DEVELOPER but action requires at least MAINTAINER.",
                     "details": {
                         "required_role": "MAINTAINER",
                         "actual_role": "DEVELOPER",
                     },
-                }
+                },
             },
         ),
         (
-            NamespaceUserRoleInt.GUEST,
+            None,
             403,
             {
                 "error": {
                     "code": "permission_denied",
-                    "message": f"Permission denied. User has role GUEST but action requires at least MAINTAINER.",
+                    "message": "Permission denied. User has role GUEST but action requires at least MAINTAINER.",
                     "details": {
                         "required_role": "MAINTAINER",
                         "actual_role": "GUEST",
                     },
-                }
+                },
             },
         ),
     ],

--- a/tests/test_backend/test_namespace/test_delete_namespace.py
+++ b/tests/test_backend/test_namespace/test_delete_namespace.py
@@ -8,13 +8,8 @@ from typing import TYPE_CHECKING
 import pytest
 from sqlalchemy import select
 
-from horizon.backend.db.models import (
-    HWM,
-    Namespace,
-    NamespaceHistory,
-    NamespaceUserRoleInt,
-    User,
-)
+from horizon.backend.db.models import HWM, Namespace, NamespaceHistory, User
+from horizon.commons.dto import Role
 
 if TYPE_CHECKING:
     from httpx import AsyncClient
@@ -63,13 +58,7 @@ async def test_delete_namespace_missing(
     }
 
 
-@pytest.mark.parametrize(
-    "user_with_role",
-    [
-        NamespaceUserRoleInt.OWNER,
-    ],
-    indirect=["user_with_role"],
-)
+@pytest.mark.parametrize("user_with_role", [Role.OWNER], indirect=True)
 async def test_delete_namespace(
     test_client: AsyncClient,
     access_token: str,
@@ -165,45 +154,45 @@ async def test_delete_namespace_with_existing_hwm(
     "user_with_role, expected_status, expected_response",
     [
         (
-            NamespaceUserRoleInt.MAINTAINER,
+            Role.MAINTAINER,
             403,
             {
                 "error": {
                     "code": "permission_denied",
-                    "message": f"Permission denied. User has role MAINTAINER but action requires at least OWNER.",
+                    "message": "Permission denied. User has role MAINTAINER but action requires at least OWNER.",
                     "details": {
                         "required_role": "OWNER",
                         "actual_role": "MAINTAINER",
                     },
-                }
+                },
             },
         ),
         (
-            NamespaceUserRoleInt.DEVELOPER,
+            Role.DEVELOPER,
             403,
             {
                 "error": {
                     "code": "permission_denied",
-                    "message": f"Permission denied. User has role DEVELOPER but action requires at least OWNER.",
+                    "message": "Permission denied. User has role DEVELOPER but action requires at least OWNER.",
                     "details": {
                         "required_role": "OWNER",
                         "actual_role": "DEVELOPER",
                     },
-                }
+                },
             },
         ),
         (
-            NamespaceUserRoleInt.GUEST,
+            None,
             403,
             {
                 "error": {
                     "code": "permission_denied",
-                    "message": f"Permission denied. User has role GUEST but action requires at least OWNER.",
+                    "message": "Permission denied. User has role GUEST but action requires at least OWNER.",
                     "details": {
                         "required_role": "OWNER",
                         "actual_role": "GUEST",
                     },
-                }
+                },
             },
         ),
     ],

--- a/tests/test_backend/test_namespace/test_update_namespace.py
+++ b/tests/test_backend/test_namespace/test_update_namespace.py
@@ -11,12 +11,8 @@ from pydantic import __version__ as pydantic_version
 from sqlalchemy import select
 from sqlalchemy_utils.functions import naturally_equivalent
 
-from horizon.backend.db.models import (
-    Namespace,
-    NamespaceHistory,
-    NamespaceUserRoleInt,
-    User,
-)
+from horizon.backend.db.models import Namespace, NamespaceHistory, User
+from horizon.commons.dto import Role
 
 if TYPE_CHECKING:
     from httpx import AsyncClient
@@ -129,13 +125,7 @@ async def test_update_namespace_name(
     assert updated_namespace_history.action == "Updated"
 
 
-@pytest.mark.parametrize(
-    "user_with_role",
-    [
-        NamespaceUserRoleInt.OWNER,
-    ],
-    indirect=["user_with_role"],
-)
+@pytest.mark.parametrize("user_with_role", [Role.OWNER], indirect=True)
 async def test_update_namespace_description(
     test_client: AsyncClient,
     access_token: str,
@@ -214,7 +204,7 @@ async def test_update_namespace_no_data(
                 "location": ["body", "__root__"],
                 "code": "value_error",
                 "message": "At least one field must be set.",
-            }
+            },
         ]
     else:
         details = [
@@ -225,7 +215,7 @@ async def test_update_namespace_no_data(
                 "context": {},
                 "input": {"unexpected": "value"},
                 "url": "https://errors.pydantic.dev/2.5/v/value_error",
-            }
+            },
         ]
 
     assert response.json() == {
@@ -233,7 +223,7 @@ async def test_update_namespace_no_data(
             "code": "invalid_request",
             "message": "Invalid request",
             "details": details,
-        }
+        },
     }
 
 
@@ -369,45 +359,45 @@ async def test_update_namespace_invalid_name_length(
     "user_with_role, expected_status, expected_response",
     [
         (
-            NamespaceUserRoleInt.MAINTAINER,
+            Role.MAINTAINER,
             403,
             {
                 "error": {
                     "code": "permission_denied",
-                    "message": f"Permission denied. User has role MAINTAINER but action requires at least OWNER.",
+                    "message": "Permission denied. User has role MAINTAINER but action requires at least OWNER.",
                     "details": {
                         "required_role": "OWNER",
                         "actual_role": "MAINTAINER",
                     },
-                }
+                },
             },
         ),
         (
-            NamespaceUserRoleInt.DEVELOPER,
+            Role.DEVELOPER,
             403,
             {
                 "error": {
                     "code": "permission_denied",
-                    "message": f"Permission denied. User has role DEVELOPER but action requires at least OWNER.",
+                    "message": "Permission denied. User has role DEVELOPER but action requires at least OWNER.",
                     "details": {
                         "required_role": "OWNER",
                         "actual_role": "DEVELOPER",
                     },
-                }
+                },
             },
         ),
         (
-            NamespaceUserRoleInt.GUEST,
+            None,
             403,
             {
                 "error": {
                     "code": "permission_denied",
-                    "message": f"Permission denied. User has role GUEST but action requires at least OWNER.",
+                    "message": "Permission denied. User has role GUEST but action requires at least OWNER.",
                     "details": {
                         "required_role": "OWNER",
                         "actual_role": "GUEST",
                     },
-                }
+                },
             },
         ),
     ],

--- a/tests/test_backend/test_permissions/test_get_permissions.py
+++ b/tests/test_backend/test_permissions/test_get_permissions.py
@@ -6,7 +6,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from horizon.backend.db.models import Namespace, NamespaceUserRoleInt, User
+from horizon.backend.db.models import Namespace, User
+from horizon.commons.dto import Role
 
 if TYPE_CHECKING:
     from httpx import AsyncClient
@@ -54,15 +55,15 @@ async def test_get_namespace_permissions_missing(
     }
 
 
-@pytest.mark.parametrize("user_with_role", [NamespaceUserRoleInt.OWNER], indirect=["user_with_role"])
+@pytest.mark.parametrize("user_with_role", [Role.OWNER], indirect=True)
 @pytest.mark.parametrize(
     "namespace_with_users",
     [
         [
-            ("user1", NamespaceUserRoleInt.DEVELOPER),
-            ("user2", NamespaceUserRoleInt.DEVELOPER),
-            ("user3", NamespaceUserRoleInt.MAINTAINER),
-        ]
+            ("user1", Role.DEVELOPER),
+            ("user2", Role.DEVELOPER),
+            ("user3", Role.MAINTAINER),
+        ],
     ],
     indirect=["namespace_with_users"],
 )
@@ -93,45 +94,45 @@ async def test_get_namespace_permissions(
     "user_with_role, expected_status, expected_response",
     [
         (
-            NamespaceUserRoleInt.MAINTAINER,
+            Role.MAINTAINER,
             403,
             {
                 "error": {
                     "code": "permission_denied",
-                    "message": f"Permission denied. User has role MAINTAINER but action requires at least OWNER.",
+                    "message": "Permission denied. User has role MAINTAINER but action requires at least OWNER.",
                     "details": {
                         "required_role": "OWNER",
                         "actual_role": "MAINTAINER",
                     },
-                }
+                },
             },
         ),
         (
-            NamespaceUserRoleInt.DEVELOPER,
+            Role.DEVELOPER,
             403,
             {
                 "error": {
                     "code": "permission_denied",
-                    "message": f"Permission denied. User has role DEVELOPER but action requires at least OWNER.",
+                    "message": "Permission denied. User has role DEVELOPER but action requires at least OWNER.",
                     "details": {
                         "required_role": "OWNER",
                         "actual_role": "DEVELOPER",
                     },
-                }
+                },
             },
         ),
         (
-            NamespaceUserRoleInt.GUEST,
+            None,
             403,
             {
                 "error": {
                     "code": "permission_denied",
-                    "message": f"Permission denied. User has role GUEST but action requires at least OWNER.",
+                    "message": "Permission denied. User has role GUEST but action requires at least OWNER.",
                     "details": {
                         "required_role": "OWNER",
                         "actual_role": "GUEST",
                     },
-                }
+                },
             },
         ),
     ],

--- a/tests/test_client_sync/test_permissions/test_client_sync_get_permissions.py
+++ b/tests/test_client_sync/test_permissions/test_client_sync_get_permissions.py
@@ -8,8 +8,9 @@ import re
 import pytest
 import requests
 
-from horizon.backend.db.models import Namespace, NamespaceUserRoleInt, User
+from horizon.backend.db.models import Namespace, User
 from horizon.client.sync import HorizonClientSync
+from horizon.commons.dto import Role
 from horizon.commons.exceptions.entity import EntityNotFoundError
 from horizon.commons.schemas.v1 import PermissionResponseItemV1, PermissionsResponseV1
 
@@ -19,7 +20,7 @@ pytestmark = [pytest.mark.client_sync, pytest.mark.client]
 def test_sync_client_get_namespace_permissions(namespace: Namespace, user: User, sync_client: HorizonClientSync):
     response = sync_client.get_namespace_permissions(namespace.id)
     assert response == PermissionsResponseV1(
-        permissions=[PermissionResponseItemV1(username=user.username, role=NamespaceUserRoleInt.OWNER.name)]
+        permissions=[PermissionResponseItemV1(username=user.username, role=Role.OWNER)],
     )
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/horizon/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

* Replace `NamespaceRepository.check_permissions` with `NamespaceRepository.get_roles`, actual permissions check is performed in HTTP endpoint.
* Rename `NamespaceRepository.update_permission` and `NamespaceRepository.delete_permission` to `NamespaceRepository.set_role` and `NamespaceRepository.delete_role`
* Merge `NamespaceUserRole` and `NamespaceUserRoleInt` enums to one `Role` enum, and use it in sqlalchemy model.
* Drop `GUEST` role, it is now just the same as lack of role (`None`).

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [ ] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/horizon/blob/develop/CONTRIBUTING.rst) for details.)
* [ ] My PR is ready to review.
