### PR TITLE
[DOP-13020] - add bulk delete hwms endpoint

### DIFF
--- a/docs/changelog/next_release/29.feature.rst
+++ b/docs/changelog/next_release/29.feature.rst
@@ -1,3 +1,3 @@
 - Add new API endpoint ``PATCH /namespace/:id/permissions`` for updating the permissions of users within a namespace.
 - Add new API endpoint ``GET /namespace/:id/permissions`` for fetching the permissions of users within a specific namespace.
-- Extend the Python client library with methods `get_namespace_permissions` and `update_namespace_permissions` to interact with the new API endpoints.
+- Extend the Python client library with methods ``get_namespace_permissions`` and ``update_namespace_permissions`` to interact with the new API endpoints.

--- a/docs/changelog/next_release/37.feature.rst
+++ b/docs/changelog/next_release/37.feature.rst
@@ -1,0 +1,2 @@
+- Add new API endpoint ``DELETE /hwm/`` for bulk deletion of High Water Marks (HWMs) by namespace_id and a list of hwm_ids.
+- Extend the Python client library with the method ``bulk_delete_hwm`` to interact with the new bulk delete HWM API endpoint.

--- a/docs/client/schemas/hwm.rst
+++ b/docs/client/schemas/hwm.rst
@@ -18,3 +18,6 @@ HWM-related schemas
 
 .. autopydantic_model:: HWMUpdateRequestV1
     :model-show-field-summary: false
+
+.. autopydantic_model:: HWMBulkDeleteRequestV1
+    :model-show-field-summary: false

--- a/docs/client/sync.rst
+++ b/docs/client/sync.rst
@@ -77,7 +77,7 @@ Reference
 .. currentmodule:: horizon.client.sync
 
 .. autoclass:: HorizonClientSync
-    :members: authorize, ping, whoami, paginate_namespaces, get_namespace, create_namespace, update_namespace, delete_namespace, paginate_hwm, get_hwm, create_hwm, update_hwm, delete_hwm, get_namespace_permissions, update_namespace_permissions, paginate_hwm_history, paginate_namespace_history, retry
+    :members: authorize, ping, whoami, paginate_namespaces, get_namespace, create_namespace, update_namespace, delete_namespace, paginate_hwm, get_hwm, create_hwm, update_hwm, delete_hwm, bulk_delete_hwm, get_namespace_permissions, update_namespace_permissions, paginate_hwm_history, paginate_namespace_history, retry
     :member-order: bysource
 
 .. autoclass:: RetryConfig

--- a/horizon/backend/api/v1/router/namespaces.py
+++ b/horizon/backend/api/v1/router/namespaces.py
@@ -120,5 +120,5 @@ async def delete_namespace(
         namespace = await unit_of_work.namespace.delete(namespace_id=namespace_id, user=user)
         await unit_of_work.namespace_history.create(
             namespace_id=namespace_id,
-            data={**namespace.to_dict(exclude={"id"}), "action": "Deleted"},
+            data={**namespace.to_dict(exclude={"id"}), "action": "Deleted", "changed_by_user_id": user.id},
         )

--- a/horizon/backend/db/repositories/hwm.py
+++ b/horizon/backend/db/repositories/hwm.py
@@ -105,11 +105,7 @@ class HWMRepository(Repository[HWM]):
         result = await self._session.execute(select(HWM).where(HWM.id.in_(hwm_ids), HWM.namespace_id == namespace_id))
         hwms_to_delete = result.scalars().all()
 
-        missing_ids = set(hwm_ids) - {hwm.id for hwm in hwms_to_delete}
-        if missing_ids:
-            raise EntityNotFoundError("HWMs", "ids", list(missing_ids))
-
         if hwms_to_delete:
-            await self._session.execute(delete(HWM).where(HWM.id.in_(hwm_ids)))
+            await self._session.execute(delete(HWM).where(HWM.id.in_([hwm.id for hwm in hwms_to_delete])))
 
         return hwms_to_delete

--- a/horizon/backend/db/repositories/hwm.py
+++ b/horizon/backend/db/repositories/hwm.py
@@ -3,7 +3,9 @@
 
 from __future__ import annotations
 
-from sqlalchemy import SQLColumnExpression
+from typing import List, Sequence
+
+from sqlalchemy import SQLColumnExpression, delete, select
 from sqlalchemy.exc import IntegrityError
 
 from horizon.backend.db.models import HWM, User
@@ -93,9 +95,21 @@ class HWMRepository(Repository[HWM]):
     async def delete(
         self,
         hwm_id: int,
-        user: User,
     ) -> HWM:
         hwm = await self.get(hwm_id)
         await self._session.delete(hwm)
         await self._session.flush()
         return hwm
+
+    async def bulk_delete(self, namespace_id: int, hwm_ids: List[int]) -> Sequence[HWM]:
+        result = await self._session.execute(select(HWM).where(HWM.id.in_(hwm_ids), HWM.namespace_id == namespace_id))
+        hwms_to_delete = result.scalars().all()
+
+        missing_ids = set(hwm_ids) - {hwm.id for hwm in hwms_to_delete}
+        if missing_ids:
+            raise EntityNotFoundError("HWMs", "ids", list(missing_ids))
+
+        if hwms_to_delete:
+            await self._session.execute(delete(HWM).where(HWM.id.in_(hwm_ids)))
+
+        return hwms_to_delete

--- a/horizon/backend/db/repositories/hwm_history.py
+++ b/horizon/backend/db/repositories/hwm_history.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-2024 MTS (Mobile Telesystems)
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List
+from __future__ import annotations
 
 from horizon.backend.db.models import HWMHistory
 from horizon.backend.db.repositories.base import Repository
@@ -37,7 +37,7 @@ class HWMHistoryRepository(Repository[HWMHistory]):
         await self._session.flush()
         return result
 
-    async def bulk_create(self, hwm_data: List[dict]) -> List[HWMHistory]:
+    async def bulk_create(self, hwm_data: list[dict]) -> list[HWMHistory]:
         hwm_histories = [HWMHistory(**data) for data in hwm_data]
         self._session.add_all(hwm_histories)
         await self._session.flush()

--- a/horizon/backend/db/repositories/hwm_history.py
+++ b/horizon/backend/db/repositories/hwm_history.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2023-2024 MTS (Mobile Telesystems)
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import List
+
 from horizon.backend.db.models import HWMHistory
 from horizon.backend.db.repositories.base import Repository
 from horizon.commons.dto import Pagination
@@ -34,3 +36,9 @@ class HWMHistoryRepository(Repository[HWMHistory]):
         )
         await self._session.flush()
         return result
+
+    async def bulk_create(self, hwm_data: List[dict]) -> List[HWMHistory]:
+        hwm_histories = [HWMHistory(**data) for data in hwm_data]
+        self._session.add_all(hwm_histories)
+        await self._session.flush()
+        return hwm_histories

--- a/horizon/client/sync.py
+++ b/horizon/client/sync.py
@@ -13,6 +13,7 @@ from horizon import __version__ as horizon_version
 from horizon.client.base import BaseClient
 from horizon.commons.schemas import PingResponse
 from horizon.commons.schemas.v1 import (
+    HWMBulkDeleteRequestV1,
     HWMCreateRequestV1,
     HWMHistoryPaginateQueryV1,
     HWMHistoryResponseV1,
@@ -755,6 +756,39 @@ class HorizonClientSync(BaseClient[OAuth2Session]):
         self._request(
             "DELETE",
             f"{self.base_url}/v1/hwm/{hwm_id}",
+        )
+
+    def bulk_delete_hwm(self, namespace_id: int, hwm_ids: List[int]) -> None:
+        """Bulk delete HWMs.
+
+        Parameters
+        ----------
+        namespace_id : int
+            Namespace ID where the HWMs belong.
+        hwm_ids : List[int]
+            List of HWM IDs to be deleted.
+
+        Raises
+        ------
+        :obj:`EntityNotFoundError <horizon.commons.exceptions.entity.EntityNotFoundError>`
+            One or more HWMs not found.
+        :obj:`PermissionDeniedError <horizon.commons.exceptions.permission.PermissionDeniedError>`
+            Permission denied for performing the requested action.
+
+        Examples
+        --------
+
+        >>> client.bulk_delete_hwm(
+        ...     namespace_id=123,
+        ...     hwm_ids=[234, 345, 456]
+        ... )
+        """
+
+        data = HWMBulkDeleteRequestV1(namespace_id=namespace_id, hwm_ids=hwm_ids)
+        self._request(
+            "DELETE",
+            f"{self.base_url}/v1/hwm/",
+            json=data.dict(),
         )
 
     def get_namespace_permissions(self, namespace_id: int) -> PermissionsResponseV1:

--- a/horizon/client/sync.py
+++ b/horizon/client/sync.py
@@ -761,6 +761,10 @@ class HorizonClientSync(BaseClient[OAuth2Session]):
     def bulk_delete_hwm(self, namespace_id: int, hwm_ids: List[int]) -> None:
         """Bulk delete HWMs.
 
+        .. note::
+
+            Method ignores HWMs that are not related to provided namespace.
+
         Parameters
         ----------
         namespace_id : int
@@ -770,8 +774,6 @@ class HorizonClientSync(BaseClient[OAuth2Session]):
 
         Raises
         ------
-        :obj:`EntityNotFoundError <horizon.commons.exceptions.entity.EntityNotFoundError>`
-            One or more HWMs not found.
         :obj:`PermissionDeniedError <horizon.commons.exceptions.permission.PermissionDeniedError>`
             Permission denied for performing the requested action.
 

--- a/horizon/commons/schemas/v1/__init__.py
+++ b/horizon/commons/schemas/v1/__init__.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from horizon.commons.schemas.v1.auth import AuthTokenResponseV1
 from horizon.commons.schemas.v1.hwm import (
+    HWMBulkDeleteRequestV1,
     HWMCreateRequestV1,
     HWMPaginateQueryV1,
     HWMResponseV1,
@@ -43,6 +44,7 @@ __all__ = [
     "HWMUpdateRequestV1",
     "HWMHistoryPaginateQueryV1",
     "HWMHistoryResponseV1",
+    "HWMBulkDeleteRequestV1",
     "NamespaceCreateRequestV1",
     "NamespacePaginateQueryV1",
     "NamespaceResponseV1",

--- a/horizon/commons/schemas/v1/hwm.py
+++ b/horizon/commons/schemas/v1/hwm.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023-2024 MTS (Mobile Telesystems)
 # SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
-from typing import Any, Optional, Union
+from typing import Any, List, Optional, Union
 
 from pydantic import BaseModel, Field, root_validator
 
@@ -80,3 +80,10 @@ class HWMUpdateRequestV1(BaseModel):
         if not values_set:
             raise ValueError("At least one field must be set.")
         return values
+
+
+class HWMBulkDeleteRequestV1(BaseModel):
+    """Schema for request body of bulk delete HWM operation."""
+
+    namespace_id: int
+    hwm_ids: List[int] = Field(min_length=1)

--- a/tests/test_backend/test_hwm/test_bulk_delete_hwm.py
+++ b/tests/test_backend/test_hwm/test_bulk_delete_hwm.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: 2023 MTS (Mobile Telesystems)
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
+
+import pytest
+from sqlalchemy import select
+
+from horizon.backend.db.models import HWM, Namespace, NamespaceUserRoleInt, User
+from horizon.backend.db.models.hwm_history import HWMHistory
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+pytestmark = [pytest.mark.backend, pytest.mark.asyncio]
+
+
+async def test_bulk_delete_hwm_anonymous_user(
+    test_client: AsyncClient,
+    namespace: Namespace,
+    new_hwm: HWM,
+):
+    response = await test_client.request(
+        method="DELETE",
+        url="v1/hwm/",
+        json={"namespace_id": namespace.id, "hwm_ids": [new_hwm.id]},
+    )
+    assert response.status_code == 401
+    assert response.json() == {
+        "error": {
+            "code": "unauthorized",
+            "message": "Not authenticated",
+            "details": None,
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "user_with_role",
+    [
+        NamespaceUserRoleInt.SUPERADMIN,
+        NamespaceUserRoleInt.OWNER,
+        NamespaceUserRoleInt.MAINTAINER,
+    ],
+    indirect=["user_with_role"],
+)
+async def test_bulk_delete_hwm(
+    test_client: AsyncClient,
+    access_token: str,
+    user_with_role: None,
+    user: User,
+    namespace: Namespace,
+    hwms: list[HWM],
+    async_session: AsyncSession,
+):
+    pre_delete_timestamp = datetime.now(timezone.utc) - timedelta(minutes=1)
+    response = await test_client.request(
+        "DELETE",
+        "v1/hwm/",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "application/json",
+        },
+        json={"namespace_id": namespace.id, "hwm_ids": [hwm.id for hwm in hwms]},
+    )
+    post_delete_timestamp = datetime.now(timezone.utc)
+
+    assert response.status_code == 204
+
+    for hwm in hwms:
+        query = select(HWM).where(HWM.id == hwm.id)
+        result = await async_session.execute(query)
+        hwm_record = result.scalars().first()
+        assert hwm_record is None
+
+        query_history = select(HWMHistory).where(HWMHistory.hwm_id == hwm.id)
+        result_history = await async_session.execute(query_history)
+        created_hwm_history = result_history.scalars().one()
+
+        assert created_hwm_history.name == hwm.name
+        assert created_hwm_history.namespace_id == hwm.namespace_id
+        assert created_hwm_history.description == hwm.description
+        assert created_hwm_history.type == hwm.type
+        assert created_hwm_history.value == hwm.value
+        assert created_hwm_history.entity == hwm.entity
+        assert created_hwm_history.expression == hwm.expression
+        assert created_hwm_history.action == "Deleted"
+        assert created_hwm_history.changed_by_user_id == user.id
+        assert pre_delete_timestamp <= created_hwm_history.changed_at <= post_delete_timestamp
+
+
+async def test_bulk_delete_not_existing_hwm(
+    test_client: AsyncClient,
+    access_token: str,
+    namespace: Namespace,
+    hwm: HWM,
+    new_hwm: HWM,
+):
+    response = await test_client.request(
+        "DELETE",
+        "v1/hwm/",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "application/json",
+        },
+        json={"namespace_id": namespace.id, "hwm_ids": [hwm.id, new_hwm.id]},
+    )
+    assert response.status_code == 404
+    assert response.json() == {
+        "error": {
+            "code": "not_found",
+            "message": f"HWMs with ids=[{new_hwm.id!r}] not found",
+            "details": {
+                "entity_type": "HWMs",
+                "field": "ids",
+                "value": [new_hwm.id],
+            },
+        },
+    }
+
+
+async def test_bulk_delete_empty_hwm_list(
+    test_client: AsyncClient,
+    access_token: str,
+    namespace: Namespace,
+):
+    response = await test_client.request(
+        "DELETE",
+        "v1/hwm/",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "application/json",
+        },
+        json={"namespace_id": namespace.id, "hwm_ids": []},
+    )
+
+    assert response.status_code == 422
+    assert "List should have at least 1 item after validation, not 0" in response.text
+
+
+@pytest.mark.parametrize(
+    "user_with_role, expected_status, expected_response",
+    [
+        (
+            NamespaceUserRoleInt.DEVELOPER,
+            403,
+            {
+                "error": {
+                    "code": "permission_denied",
+                    "message": f"Permission denied. User has role DEVELOPER but action requires at least MAINTAINER.",
+                    "details": {
+                        "required_role": "MAINTAINER",
+                        "actual_role": "DEVELOPER",
+                    },
+                }
+            },
+        ),
+        (
+            NamespaceUserRoleInt.GUEST,
+            403,
+            {
+                "error": {
+                    "code": "permission_denied",
+                    "message": f"Permission denied. User has role GUEST but action requires at least MAINTAINER.",
+                    "details": {
+                        "required_role": "MAINTAINER",
+                        "actual_role": "GUEST",
+                    },
+                }
+            },
+        ),
+    ],
+    indirect=["user_with_role"],
+)
+async def test_bulk_delete_hwm_permission_denied(
+    user_with_role: None,
+    expected_status: int,
+    expected_response: dict,
+    test_client: AsyncClient,
+    access_token: str,
+    namespace: Namespace,
+    hwm: HWM,
+):
+    response = await test_client.request(
+        "DELETE",
+        "v1/hwm/",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "application/json",
+        },
+        json={"namespace_id": namespace.id, "hwm_ids": [hwm.id]},
+    )
+    assert response.status_code == expected_status
+    assert response.json() == expected_response

--- a/tests/test_backend/test_hwm/test_bulk_delete_hwm.py
+++ b/tests/test_backend/test_hwm/test_bulk_delete_hwm.py
@@ -108,18 +108,8 @@ async def test_bulk_delete_not_existing_hwm(
         },
         json={"namespace_id": namespace.id, "hwm_ids": [hwm.id, new_hwm.id]},
     )
-    assert response.status_code == 404
-    assert response.json() == {
-        "error": {
-            "code": "not_found",
-            "message": f"HWMs with ids=[{new_hwm.id!r}] not found",
-            "details": {
-                "entity_type": "HWMs",
-                "field": "ids",
-                "value": [new_hwm.id],
-            },
-        },
-    }
+    # we ignore hwms that are not related to namespace and delete only existing hws in namespace
+    assert response.status_code == 204
 
 
 async def test_bulk_delete_empty_hwm_list(

--- a/tests/test_client_sync/test_hwm/test_client_sync_bulk_delete_hwms.py
+++ b/tests/test_client_sync/test_hwm/test_client_sync_bulk_delete_hwms.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2023 MTS (Mobile Telesystems)
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, List
+
+import pytest
+import requests
+
+from horizon.client.sync import HorizonClientSync
+from horizon.commons.exceptions.entity import EntityNotFoundError
+
+if TYPE_CHECKING:
+    from horizon.backend.db.models import HWM, Namespace
+
+pytestmark = [pytest.mark.client_sync, pytest.mark.client]
+
+
+def test_sync_client_bulk_delete_hwm(namespace: Namespace, hwms: List[HWM], sync_client: HorizonClientSync):
+    hwm_ids = [hwm.id for hwm in hwms]
+    response = sync_client.bulk_delete_hwm(namespace_id=namespace.id, hwm_ids=hwm_ids)
+    assert response is None
+
+    for hwm_id in hwm_ids:
+        with pytest.raises(EntityNotFoundError):
+            sync_client.get_hwm(hwm_id)
+
+
+def test_sync_client_bulk_delete_hwm_missing(
+    namespace: Namespace,
+    hwm: HWM,
+    new_hwm: HWM,
+    sync_client: HorizonClientSync,
+):
+    with pytest.raises(
+        EntityNotFoundError,
+        match=re.escape(f"HWMs with ids=[{new_hwm.id!r}] not found"),
+    ) as e:
+        sync_client.bulk_delete_hwm(namespace_id=namespace.id, hwm_ids=[hwm.id, new_hwm.id])
+
+    assert e.value.details == {
+        "entity_type": "HWMs",
+        "field": "ids",
+        "value": [new_hwm.id],
+    }
+
+    # original HTTP exception is attached as reason
+    assert isinstance(e.value.__cause__, requests.exceptions.HTTPError)
+    assert e.value.__cause__.response.status_code == 404
+
+
+def test_sync_client_bulk_delete_hwm_malformed(sync_client: HorizonClientSync):
+    with pytest.raises(ValueError):
+        sync_client.bulk_delete_hwm("", "")

--- a/tests/test_client_sync/test_hwm/test_client_sync_delete_hwm.py
+++ b/tests/test_client_sync/test_hwm/test_client_sync_delete_hwm.py
@@ -49,5 +49,8 @@ def test_sync_client_delete_hwm_missing(
 
 
 def test_sync_client_delete_hwm_malformed(sync_client: HorizonClientSync):
-    with pytest.raises(requests.exceptions.HTTPError, match="405 Client Error: Method Not Allowed for url"):
+    with pytest.raises(
+        requests.exceptions.HTTPError,
+        match="422 Client Error: Unprocessable Entity for url: http://localhost:8000/v1/hwm/",
+    ):
         sync_client.delete_hwm("")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/horizon/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

 - Add new API endpoint ``DELETE /hwm/`` for bulk deletion of High Water Marks (HWMs) by namespace_id and a list of hwm_ids.
- Extend the Python client library with the method ``bulk_delete_hwms`` to interact with the new bulk delete HWM API endpoint.
- Update following documentation and tests

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Commit message and PR title is comprehensive
* [x] Keep the change as small as possible
* [x] Unit and integration tests for the changes exist
* [x] Tests pass on CI and coverage does not decrease
* [x] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/horizon/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
