### PR TITLE
[DOP-13013] Return actual permissions in update_permissions

### DIFF
--- a/horizon/client/sync.py
+++ b/horizon/client/sync.py
@@ -842,7 +842,7 @@ class HorizonClientSync(BaseClient[OAuth2Session]):
         Returns
         -------
         :obj:`PermissionsResponseV1 <horizon.commons.schemas.v1.permission.PermissionsResponseV1>`
-            The permissions of the namespace.
+            Actual permissions of the namespace.
 
         Raises
         ------
@@ -857,7 +857,11 @@ class HorizonClientSync(BaseClient[OAuth2Session]):
         --------
 
         >>> from horizon.commons.schemas.v1 import PermissionsUpdateRequestV1, PermissionUpdateRequestItemV1
-        >>> to_update = PermissionsUpdateRequestV1([PermissionUpdateRequestItemV1(role="OWNER", username="needed_user")])
+        >>> to_update = PermissionsUpdateRequestV1([
+        ...     PermissionUpdateRequestItemV1(username="new_owner", role="OWNER"),
+        ...     PermissionUpdateRequestItemV1(username="add_developer", role="DEVELOPER"),
+        ...     PermissionUpdateRequestItemV1(username="make_read_only", role=None),
+        ... ])
         >>> client.update_namespace_permissions(namespace_id=234, changes=to_update)
         """
         return self._request(  # type: ignore[return-value]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/horizon/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Instead of returning permissions passed to `update_permissions` as input, return list of actual permissions of the namespace.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/horizon/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
