### PR TITLE
[DOP-14540] Allow Docker entrypoint to automatically create SUPERADMIN users

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,9 @@ services:
     image: mtsrus/horizon-backend:develop
     restart: unless-stopped
     env_file: .env.docker
+    environment:
+      # list here usernames which should be assigned SUPERADMIN role on application start
+      - HORIZON__ENTRYPOINT__ADMIN_USERS=admin
     ports:
       - 8000:8000
     depends_on:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,4 +2,12 @@
 set -e
 
 python -m horizon.backend.db.migrations upgrade head
+
+# user only by entrypoint
+if [[ "x${HORIZON__ENTRYPOINT__ADMIN_USERS}" != "x" ]]; then
+  admins=$(echo "${HORIZON__ENTRYPOINT__ADMIN_USERS}" | tr "," " ")
+  python -m horizon.backend.scripts.manage_admins add ${admins}
+  python -m horizon.backend.scripts.manage_admins list
+fi
+
 python -m horizon.backend --host 0.0.0.0 --port 8000 "$@"

--- a/docs/backend/install.rst
+++ b/docs/backend/install.rst
@@ -28,6 +28,8 @@ Options can be set via ``.env`` file or ``environment`` section in ``docker-comp
 
 After container is started and ready, open http://localhost:8000/docs.
 
+Users listed in ``HORIZON__ENTRYPOINT__ADMIN_USERS`` env variable will be automatically promoted to ``SUPERADMIN`` role.
+
 Without docker
 --------------
 
@@ -101,3 +103,14 @@ This is a thin wrapper around `uvicorn <https://www.uvicorn.org/#command-line-op
 options and commands are just the same.
 
 After server is started and ready, open http://localhost:8000/docs.
+
+Add admin users
+~~~~~~~~~~~~~~~
+
+To promote specific users to ``SUPERADMIN`` role, run the following script:
+
+.. code-block:: console
+
+    $ python -m horizon.backend.scripts.manage_admins add admin1 admin2
+
+See :ref:`scripts` documentation.

--- a/docs/backend/scripts/index.rst
+++ b/docs/backend/scripts/index.rst
@@ -1,3 +1,5 @@
+.. _scripts:
+
 Scripts
 =======
 

--- a/docs/changelog/next_release/45.feature.rst
+++ b/docs/changelog/next_release/45.feature.rst
@@ -1,0 +1,2 @@
+Add new environment variable ``HORIZON__ENTRYPOINT__ADMIN_USERS`` to Docker image entrypoint.
+Here you can pass of usernames which should be automatically promoted to ``SUPERADMIN`` role during backend startup.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/horizon/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Now Docker image entrypoint can automatically create `SUPERADMIN` users during startup, using `HORIZON__ENTRYPOINT__ADMIN_USERS` env variable.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/horizon/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
