### PR TITLE
[DOP-15650] Apply timeout to LDAP connection pool

### DIFF
--- a/docs/changelog/next_release/58.bugfix.rst
+++ b/docs/changelog/next_release/58.bugfix.rst
@@ -1,0 +1,1 @@
+Use connection timeout while creating LDAP connections in the pool.

--- a/horizon/backend/api/handlers.py
+++ b/horizon/backend/api/handlers.py
@@ -53,7 +53,7 @@ def unknown_exception_handler(request: Request, exc: Exception) -> Response:
 
 
 def service_exception_handler(request: Request, exc: ServiceError) -> Response:
-    logger.exception("Got service error")
+    logger.exception("Got service error", exc_info=exc)
 
     server: ServerSettings = request.app.state.settings.server
     details = None

--- a/horizon/backend/providers/auth/ldap.py
+++ b/horizon/backend/providers/auth/ldap.py
@@ -136,6 +136,7 @@ class LDAPAuthProvider(AuthProvider):
             client,
             minconn=settings.ldap.lookup.pool.initial,
             maxconn=settings.ldap.lookup.pool.max,
+            timeout=settings.ldap.timeout_seconds,
         )
 
     @asynccontextmanager


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/horizon/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Every interaction with LDAP uses a timeout from settings. Except creating LDAP connection pool, fixed.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [x] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/horizon/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
