### PR TITLE
[DOP-23149] Replace python-jose with authlib.jose

### DIFF
--- a/docs/changelog/next_release/97.improvement.rst
+++ b/docs/changelog/next_release/97.improvement.rst
@@ -1,0 +1,1 @@
+Replace outdated ``python-jose`` dependency with ``authlib.jose``, to fix security issues.

--- a/horizon/backend/settings/auth/jwt.py
+++ b/horizon/backend/settings/auth/jwt.py
@@ -33,7 +33,7 @@ class JWTSettings(BaseModel):
             """
             Algorithm used for signing JWT tokens.
 
-            See `python-jose <https://python-jose.readthedocs.io/en/latest/jws/index.html#supported-algorithms>`_
+            See `authlib <https://docs.authlib.org/en/latest/specs/rfc7518.html>`_
             documentation.
             """,
         ),

--- a/horizon/backend/utils/jwt.py
+++ b/horizon/backend/utils/jwt.py
@@ -1,29 +1,29 @@
 # SPDX-FileCopyrightText: 2023-2025 MTS PJSC
 # SPDX-License-Identifier: Apache-2.0
 
-from jose import ExpiredSignatureError, JWTError, jwt
+from authlib.jose import JsonWebToken
+from authlib.jose.errors import ExpiredTokenError, JoseError
 
 from horizon.commons.exceptions import AuthorizationError
 
 
 def sign_jwt(payload: dict, secret_key: str, security_algorithm: str) -> str:
+    jwt = JsonWebToken([security_algorithm])
     return jwt.encode(
-        payload,
-        secret_key,
-        algorithm=security_algorithm,
-    )
+        header={"alg": security_algorithm},
+        payload=payload,
+        key=secret_key,
+    ).decode("utf-8")
 
 
 def decode_jwt(token: str, secret_key: str, security_algorithm: str) -> dict:
     try:
-        result = jwt.decode(
-            token,
-            secret_key,
-            algorithms=[security_algorithm],
-        )
+        result = JsonWebToken([security_algorithm]).decode(token, key=secret_key)
         if "exp" not in result:
-            raise ExpiredSignatureError("Missing expiration time in token")
+            raise ExpiredTokenError("Missing expiration time in token")
+
+        result.validate()
 
         return result
-    except JWTError as e:
+    except JoseError as e:
         raise AuthorizationError("Invalid token") from e

--- a/poetry.lock
+++ b/poetry.lock
@@ -466,7 +466,7 @@ description = "The ultimate Python library in building OAuth and OpenID Connect 
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "python_version == \"3.7\" and extra == \"client-sync\""
+markers = "extra == \"backend\" and python_version == \"3.7\" or extra == \"client-sync\" and python_version == \"3.7\""
 files = [
     {file = "Authlib-1.2.1-py2.py3-none-any.whl", hash = "sha256:c88984ea00149a90e3537c964327da930779afa4564e354edfd98410bea01911"},
     {file = "Authlib-1.2.1.tar.gz", hash = "sha256:421f7c6b468d907ca2d9afede256f068f87e34d23dd221c07d13d4c234726afb"},
@@ -482,7 +482,7 @@ description = "The ultimate Python library in building OAuth and OpenID Connect 
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "python_version == \"3.8\" and extra == \"client-sync\" or python_version >= \"3.9\" and extra == \"client-sync\""
+markers = "python_version == \"3.8\" and extra == \"backend\" or python_version == \"3.8\" and extra == \"client-sync\" or python_version >= \"3.9\" and extra == \"backend\" or python_version >= \"3.9\" and extra == \"client-sync\""
 files = [
     {file = "Authlib-1.3.2-py2.py3-none-any.whl", hash = "sha256:ede026a95e9f5cdc2d4364a52103f5405e75aa156357e831ef2bfd0bc5094dfc"},
     {file = "authlib-1.3.2.tar.gz", hash = "sha256:4b16130117f9eb82aa6eec97f6dd4673c3f960ac0283ccdae2897ee4bc030ba2"},
@@ -1269,10 +1269,10 @@ toml = ["tomli"]
 name = "cryptography"
 version = "43.0.3"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
-optional = false
+optional = true
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "python_version == \"3.8\" or python_version >= \"3.9\" or python_version == \"3.7\""
+markers = "(extra == \"backend\" or extra == \"client-sync\") and (python_version == \"3.7\" or python_version == \"3.8\" or python_version >= \"3.9\")"
 files = [
     {file = "cryptography-43.0.3-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:bf7a1932ac4176486eab36a19ed4c0492da5d97123f1406cf15e41b05e787d2e"},
     {file = "cryptography-43.0.3-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:63efa177ff54aec6e1c0aefaa1a241232dcd37413835a9b674b6e3f0ae2bfd3e"},
@@ -1385,26 +1385,6 @@ files = [
     {file = "docutils-0.21.2.tar.gz", hash = "sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f"},
 ]
 markers = {dev = "python_version == \"3.9\"", docs = "python_version == \"3.9\" or python_version >= \"3.10\""}
-
-[[package]]
-name = "ecdsa"
-version = "0.19.0"
-description = "ECDSA cryptographic signature library (pure python)"
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.6"
-groups = ["main"]
-markers = "python_version == \"3.8\" or python_version >= \"3.9\" or python_version == \"3.7\""
-files = [
-    {file = "ecdsa-0.19.0-py2.py3-none-any.whl", hash = "sha256:2cea9b88407fdac7bbeca0833b189e4c9c53f2ef1e1eaa29f6224dbc809b707a"},
-    {file = "ecdsa-0.19.0.tar.gz", hash = "sha256:60eaad1199659900dd0af521ed462b793bbdf867432b3948e87416ae4caf6bf8"},
-]
-
-[package.dependencies]
-six = ">=1.9.0"
-
-[package.extras]
-gmpy = ["gmpy"]
-gmpy2 = ["gmpy2"]
 
 [[package]]
 name = "eradicate"
@@ -3077,19 +3057,6 @@ files = [
 ]
 
 [[package]]
-name = "pyasn1"
-version = "0.5.1"
-description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
-groups = ["main"]
-markers = "python_version == \"3.8\" or python_version >= \"3.9\" or python_version == \"3.7\""
-files = [
-    {file = "pyasn1-0.5.1-py2.py3-none-any.whl", hash = "sha256:4439847c58d40b1d0a573d07e3856e95333f1976294494c325775aeca506eb58"},
-    {file = "pyasn1-0.5.1.tar.gz", hash = "sha256:6d391a96e59b23130a5cfa74d6fd7f388dbbe26cc8f1edf39fdddf08d9d6676c"},
-]
-
-[[package]]
 name = "pycodestyle"
 version = "2.12.1"
 description = "Python style guide checker"
@@ -3735,30 +3702,6 @@ markers = {main = "python_version == \"3.8\" and extra == \"backend\" or python_
 cli = ["click (>=5.0)"]
 
 [[package]]
-name = "python-jose"
-version = "3.3.0"
-description = "JOSE implementation in Python"
-optional = false
-python-versions = "*"
-groups = ["main"]
-markers = "python_version == \"3.8\" or python_version >= \"3.9\" or python_version == \"3.7\""
-files = [
-    {file = "python-jose-3.3.0.tar.gz", hash = "sha256:55779b5e6ad599c6336191246e95eb2293a9ddebd555f796a65f838f07e5d78a"},
-    {file = "python_jose-3.3.0-py2.py3-none-any.whl", hash = "sha256:9b1376b023f8b298536eedd47ae1089bcdb848f1535ab30555cd92002d78923a"},
-]
-
-[package.dependencies]
-cryptography = {version = ">=3.4.0", optional = true, markers = "extra == \"cryptography\""}
-ecdsa = "!=0.15"
-pyasn1 = "*"
-rsa = "*"
-
-[package.extras]
-cryptography = ["cryptography (>=3.4.0)"]
-pycrypto = ["pyasn1", "pycrypto (>=2.6.0,<2.7.0)"]
-pycryptodome = ["pyasn1", "pycryptodome (>=3.3.1,<4.0.0)"]
-
-[[package]]
 name = "python-json-logger"
 version = "3.0.1"
 description = "JSON Log Formatter for the Python Logging Package"
@@ -3983,22 +3926,6 @@ typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.1
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
-name = "rsa"
-version = "4.9"
-description = "Pure-Python RSA implementation"
-optional = false
-python-versions = ">=3.6,<4"
-groups = ["main"]
-markers = "python_version == \"3.8\" or python_version >= \"3.9\" or python_version == \"3.7\""
-files = [
-    {file = "rsa-4.9-py3-none-any.whl", hash = "sha256:90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7"},
-    {file = "rsa-4.9.tar.gz", hash = "sha256:e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21"},
-]
-
-[package.dependencies]
-pyasn1 = ">=0.1.3"
-
-[[package]]
 name = "setuptools"
 version = "75.3.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -4024,10 +3951,10 @@ type = ["importlib-metadata (>=7.0.2)", "jaraco.develop (>=7.21)", "mypy (==1.12
 name = "six"
 version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
-optional = false
+optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 groups = ["main"]
-markers = "python_version == \"3.8\" or python_version >= \"3.9\" or python_version == \"3.7\""
+markers = "(python_version == \"3.7\" or python_version == \"3.8\" or python_version >= \"3.9\") and extra == \"backend\""
 files = [
     {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
     {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
@@ -4888,35 +4815,6 @@ files = [
 ]
 
 [[package]]
-name = "types-pyasn1"
-version = "0.6.0.20240913"
-description = "Typing stubs for pyasn1"
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-markers = "python_version == \"3.8\" or python_version >= \"3.9\""
-files = [
-    {file = "types-pyasn1-0.6.0.20240913.tar.gz", hash = "sha256:a1da054db13d3d4ccfa69c515678154014336ad3d9f9ade01845f9edb1a2bc71"},
-    {file = "types_pyasn1-0.6.0.20240913-py3-none-any.whl", hash = "sha256:95f3cb1fbd63ff91cd0410945f8aeae6b0be359533c00f39d8e17124884157af"},
-]
-
-[[package]]
-name = "types-python-jose"
-version = "3.3.4.20240106"
-description = "Typing stubs for python-jose"
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-markers = "python_version == \"3.8\" or python_version >= \"3.9\""
-files = [
-    {file = "types-python-jose-3.3.4.20240106.tar.gz", hash = "sha256:b18cf8c5080bbfe1ef7c3b707986435d9efca3e90889acb6a06f65e06bc3405a"},
-    {file = "types_python_jose-3.3.4.20240106-py3-none-any.whl", hash = "sha256:b515a6c0c61f5e2a53bc93e3a2b024cbd42563e2e19cbde9fd1c2cc2cfe77ccc"},
-]
-
-[package.dependencies]
-types-pyasn1 = "*"
-
-[[package]]
 name = "types-pyyaml"
 version = "6.0.12.12"
 description = "Typing stubs for PyYAML"
@@ -5351,7 +5249,7 @@ test = ["coverage[toml]", "zope.event", "zope.testing"]
 testing = ["coverage[toml]", "zope.event", "zope.testing"]
 
 [extras]
-backend = ["alembic", "alembic", "asgi-correlation-id", "asgi-correlation-id", "coloredlogs", "devtools", "fastapi", "fastapi", "importlib-resources", "importlib-resources", "passlib", "pydantic-settings", "pydantic-settings", "python-json-logger", "python-multipart", "python-multipart", "pyyaml", "sqlalchemy", "sqlalchemy-utils", "starlette", "starlette", "starlette-exporter", "starlette-exporter", "uuid6", "uuid6", "uvicorn", "uvicorn"]
+backend = ["alembic", "alembic", "asgi-correlation-id", "asgi-correlation-id", "authlib", "authlib", "coloredlogs", "devtools", "fastapi", "fastapi", "importlib-resources", "importlib-resources", "passlib", "pydantic-settings", "pydantic-settings", "python-json-logger", "python-multipart", "python-multipart", "pyyaml", "sqlalchemy", "sqlalchemy-utils", "starlette", "starlette", "starlette-exporter", "starlette-exporter", "uuid6", "uuid6", "uvicorn", "uvicorn"]
 client-sync = ["authlib", "authlib", "requests", "urllib3"]
 ldap = ["argon2-cffi", "bonsai"]
 postgres = ["asyncpg", "asyncpg"]
@@ -5359,4 +5257,4 @@ postgres = ["asyncpg", "asyncpg"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.7"
-content-hash = "9c71eb4450c0a77b5dd283864878628ce58cd6e48a39d556494609beb6967d16"
+content-hash = "8bc74d31f55629684901731997355f48370381d0a97fe87bfdc3df7ba6ed669a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "data-horizon"
-version = "1.0.3"
+version = "1.1.0"
 license = "Apache-2.0"
 description = "Horizon REST API + client"
 authors = ["DataOps.ETL <onetools@mts.ru>"]
@@ -57,7 +57,6 @@ typing-extensions = [
   {version = ">=4.0.0,<4.8.0", python = "3.7"},
   {version = ">=4.0.0", python = ">=3.8"},
 ]
-python-jose = {version = "*", extras=["cryptography"]}
 fastapi = [
   {version = "^0.103.2", optional = true, python = "3.7"},
   {version = ">=0.103.0", optional = true, python = ">=3.8"},
@@ -141,6 +140,7 @@ backend = [
   "pydantic-settings",
   "devtools",
   "passlib",
+  "authlib",
 ]
 postgres = [
   "asyncpg",
@@ -214,7 +214,6 @@ wemake-python-styleguide = [
     {version = "^1.0.0", python = ">=3.10"},
 ]
 flake8-pyproject = {version = "^1.2.3", python = ">=3.8"}
-types-python-jose = {version = "^3.3.4", python = ">=3.8"}
 types-passlib = {version = "^1.7.7", python = ">=3.8"}
 types-pyyaml = [
   {version = "6.0.12.12", python = "3.7"},

--- a/tests/test_client/test_auth/test_access_token.py
+++ b/tests/test_client/test_auth/test_access_token.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pytest
-from jose import ExpiredSignatureError, JWTError
+from authlib.jose.errors import ExpiredTokenError, JoseError
 
 from horizon.client.auth import AccessToken
 
@@ -9,15 +9,15 @@ pytestmark = [pytest.mark.client_sync, pytest.mark.client]
 
 
 def test_access_token_constructor_expired(access_token_expired: AccessToken):
-    with pytest.raises(ExpiredSignatureError):
+    with pytest.raises(ExpiredTokenError):
         AccessToken(token=access_token_expired)
 
 
 def test_access_token_constructor_no_expiration_time(access_token_no_expiration_time: AccessToken):
-    with pytest.raises(ExpiredSignatureError):
+    with pytest.raises(ExpiredTokenError):
         AccessToken(token=access_token_no_expiration_time)
 
 
 def test_access_token_constructor_malformed(access_token_malformed: AccessToken):
-    with pytest.raises(JWTError):
+    with pytest.raises(JoseError):
         AccessToken(token=access_token_malformed)

--- a/tests/test_client_sync/test_hwm/test_client_sync_delete_hwm.py
+++ b/tests/test_client_sync/test_hwm/test_client_sync_delete_hwm.py
@@ -46,8 +46,5 @@ def test_sync_client_delete_hwm_missing(
 
 
 def test_sync_client_delete_hwm_malformed(sync_client: HorizonClientSync):
-    with pytest.raises(
-        requests.exceptions.HTTPError,
-        match="422 Client Error: Unprocessable Entity for url: http://localhost:8000/v1/hwm/",
-    ):
+    with pytest.raises(requests.exceptions.HTTPError, match="422 Client Error"):
         sync_client.delete_hwm("")

--- a/tests/test_client_sync/test_hwm/test_client_sync_get_hwm.py
+++ b/tests/test_client_sync/test_hwm/test_client_sync_get_hwm.py
@@ -53,5 +53,5 @@ def test_sync_client_get_hwm_missing(new_hwm: HWM, sync_client: HorizonClientSyn
 
 def test_sync_client_get_hwm_with_wrong_params(sync_client: HorizonClientSync):
     # hwm_id has wrong type, raw exception is raised
-    with pytest.raises(requests.exceptions.HTTPError, match="422 Client Error: Unprocessable Entity"):
+    with pytest.raises(requests.exceptions.HTTPError, match="422 Client Error"):
         sync_client.get_hwm("abc")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/horizon/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

python-jose last release version was in 2021. Replace it with a modern library.
In other projects, I've used `pyjwt`, but here we already use `authlib` in client code, so reuse it in backend as well.

Bumped version to 1.1.0 as this may influence users.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/horizon/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
